### PR TITLE
Add /fi rename command for fiefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- `/fi rename "new name"` command allowing fief owners to rename their fief (`fiefs.rename`)
+
 ## [0.11.0]
 
 ### Added

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -16,6 +16,7 @@ All commands use `/fi` or `/fiefs` as the base. Fiefs requires Medieval Factions
 | `/fi kick` | Kick a player from your fief. | `fiefs.kick` |
 | `/fi transfer` | Transfer ownership of your fief to another player. | `fiefs.transfer` |
 | `/fi desc` | Set a description for your fief. | `fiefs.desc` |
+| `/fi rename` | Rename your fief. | `fiefs.rename` |
 | `/fi claim` | Claim a chunk of faction land for your fief. | `fiefs.claim` |
 | `/fi unclaim` | Unclaim a chunk of land from your fief. | `fiefs.unclaim` |
 | `/fi checkclaim` | Check which fief owns the chunk you are standing in. | `fiefs.checkclaim` |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -38,6 +38,7 @@ Fiefs is a Spigot plugin that adds a sub-faction territory system to Medieval Fa
 | `fiefs.kick` | `true` | Kick a player from a fief. |
 | `fiefs.transfer` | `true` | Transfer fief ownership. |
 | `fiefs.desc` | `true` | Set a fief description. |
+| `fiefs.rename` | `true` | Rename a fief. |
 | `fiefs.claim` | `true` | Claim a chunk for a fief. |
 | `fiefs.unclaim` | `true` | Unclaim a chunk from a fief. |
 | `fiefs.checkclaim` | `true` | Check which fief owns a chunk. |

--- a/src/main/java/dansplugins/fiefs/Fiefs.java
+++ b/src/main/java/dansplugins/fiefs/Fiefs.java
@@ -174,6 +174,7 @@ public final class Fiefs extends PonderBukkitPlugin {
                 new LeaveCommand(medievalFactionsIntegrator, persistentData),
                 new ListCommand(medievalFactionsIntegrator, persistentData),
                 new MembersCommand(medievalFactionsIntegrator, persistentData),
+                new RenameCommand(medievalFactionsIntegrator, persistentData),
                 new TransferCommand(medievalFactionsIntegrator, persistentData),
                 new UnclaimCommand(medievalFactionsIntegrator, persistentData, chunkService)
         ));

--- a/src/main/java/dansplugins/fiefs/commands/HelpCommand.java
+++ b/src/main/java/dansplugins/fiefs/commands/HelpCommand.java
@@ -67,6 +67,7 @@ public class HelpCommand extends AbstractPluginCommand {
         sender.sendMessage(ChatColor.AQUA + "/fi claim - Claim a chunk of land for your fief.");
         sender.sendMessage(ChatColor.AQUA + "/fi unclaim - Unclaim a chunk of land for your fief.");
         sender.sendMessage(ChatColor.AQUA + "/fi desc - Alter the description of your fief.");
+        sender.sendMessage(ChatColor.AQUA + "/fi rename - Rename your fief.");
         sender.sendMessage(ChatColor.AQUA + "/fi kick - Kick a player from your fief.");
         sender.sendMessage(ChatColor.AQUA + "/fi transfer - Transfer your fief to another player.");
         sender.sendMessage(ChatColor.AQUA + "/fi flags - View and alter your fief's configuration.");

--- a/src/main/java/dansplugins/fiefs/commands/RenameCommand.java
+++ b/src/main/java/dansplugins/fiefs/commands/RenameCommand.java
@@ -1,0 +1,78 @@
+package dansplugins.fiefs.commands;
+
+import com.dansplugins.factionsystem.faction.MfFaction;
+import dansplugins.fiefs.data.PersistentData;
+import dansplugins.fiefs.integrators.MedievalFactionsIntegrator;
+import dansplugins.fiefs.objects.Fief;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
+import preponderous.ponder.misc.ArgumentParser;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/**
+ * @author Daniel McCoy Stephenson
+ */
+public class RenameCommand extends AbstractPluginCommand {
+    private final MedievalFactionsIntegrator medievalFactionsIntegrator;
+    private final PersistentData persistentData;
+
+    public RenameCommand(MedievalFactionsIntegrator medievalFactionsIntegrator, PersistentData persistentData) {
+        super(new ArrayList<>(Arrays.asList("rename")), new ArrayList<>(Arrays.asList("fiefs.rename")));
+        this.medievalFactionsIntegrator = medievalFactionsIntegrator;
+        this.persistentData = persistentData;
+    }
+
+    @Override
+    public boolean execute(CommandSender commandSender) {
+        commandSender.sendMessage(ChatColor.RED + "Usage: /fiefs rename \"new name\"");
+        return false;
+    }
+
+    public boolean execute(CommandSender sender, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return false;
+        }
+
+        Player player = (Player) sender;
+
+        MfFaction faction = medievalFactionsIntegrator.getFactionForPlayer(player);
+        if (faction == null) {
+            return false;
+        }
+
+        Fief playersFief = persistentData.getFief(player);
+        if (playersFief == null) {
+            player.sendMessage(ChatColor.RED + "You must be in a fief to use this command.");
+            return false;
+        }
+
+        if (!playersFief.getOwnerUUID().equals(player.getUniqueId())) {
+            player.sendMessage(ChatColor.RED + "You must be the owner of your fief to rename it.");
+            return false;
+        }
+
+        ArgumentParser argumentParser = new ArgumentParser();
+        ArrayList<String> singleQuoteArgs = new ArrayList<>(argumentParser.getArgumentsInsideDoubleQuotes(args));
+
+        if (singleQuoteArgs.size() == 0) {
+            player.sendMessage(ChatColor.RED + "You must put the new name of your fief in between double quotes.");
+            return false;
+        }
+
+        String newName = singleQuoteArgs.get(0);
+
+        if (persistentData.isNameTaken(newName)) {
+            player.sendMessage(ChatColor.RED + "That name is taken.");
+            return false;
+        }
+
+        playersFief.setName(newName);
+        player.sendMessage(ChatColor.GREEN + "Fief renamed.");
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -40,6 +40,8 @@ permissions:
     default: true
   fiefs.transfer:
     default: true
+  fiefs.rename:
+    default: true
   fiefs.flags:
     default: true
   fiefs.config:


### PR DESCRIPTION
## Summary
- Adds a new `/fi rename "new name"` command (`fiefs.rename` permission, default true) allowing a fief's owner to rename it, following the same owner-check/name-validation pattern as `CreateCommand`/`TransferCommand`.
- Registers `RenameCommand` in `Fiefs.java`, adds the permission node to `plugin.yml`, and updates `HelpCommand`, `COMMANDS.md`, `USER_GUIDE.md`, and `CHANGELOG.md` to keep docs/perms in sync.

## Test plan
- `mvn clean package` — PASS, shaded JAR produced at `target/Fiefs-0.11.0-SNAPSHOT.jar`.
- Runtime behavior (owner-only rename, name-taken rejection) can only be exercised on a live server with a matching Medieval Factions JAR; no automated test suite exists in this repo yet. Manual validation steps: build the JAR, drop it plus a matching MF JAR into a test server's `plugins/`, create a fief, run `/fi rename "New Name"` as owner (expect success + `/fi info` reflects new name), run it as a non-owner member (expect rejection), and run it with a name already in use by another fief (expect "That name is taken.").

## Triage notes
This cycle also closed 16 stale issues (#116-123, #126-132, #134) that described features already implemented in `commands/` and `listeners/FactionEventListener.java`. Issue #124 ("identify which fief a player is in") remains open — deferred to a future cycle as a separate, unrelated command addition.

Closes #125

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
