### PR TITLE
Fix /fi desc usage message to use double quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   was looked up by fief name using the player's name instead of by their UUID
 - `/fi invite` no longer invites a player who already belongs to another fief; the "already in a
   fief" check was looking the target up by fief name and never matched
+- `/fi desc`'s no-argument usage message now shows double quotes, matching the double-quote parsing
+  the command actually requires
 
 ## [0.11.0]
 

--- a/src/main/java/dansplugins/fiefs/commands/DescCommand.java
+++ b/src/main/java/dansplugins/fiefs/commands/DescCommand.java
@@ -28,7 +28,7 @@ public class DescCommand extends AbstractPluginCommand {
 
     @Override
     public boolean execute(CommandSender commandSender) {
-        commandSender.sendMessage(ChatColor.RED + "Usage: /fiefs desc 'new description'");
+        commandSender.sendMessage(ChatColor.RED + "Usage: /fiefs desc \"new description\"");
         return false;
     }
 


### PR DESCRIPTION
## Summary
- `DescCommand`'s no-argument usage message advertised single quotes (`/fiefs desc 'new description'`) but the command only parses arguments wrapped in **double** quotes (`getArgumentsInsideDoubleQuotes`) and its own rejection message says so. A player following the usage message literally got rejected by a message contradicting the one they just followed.
- Updated the usage string to double quotes, matching `CreateCommand` and `RenameCommand`.
- Added a CHANGELOG entry under `[Unreleased] / Fixed`.

## Test plan
- `mvn clean package` (offline): **PASS**, shaded JAR built without errors.
- No automated test suite exists in this repo; this is a static string change with no behavior branching, so no new unit test was added. Manual validation: run `/fi desc` with no arguments in-game and confirm the message reads `Usage: /fiefs desc "new description"`.

## Notes
- No doc drift: `COMMANDS.md` / `USER_GUIDE.md` describe `/fi desc` generically and don't quote the usage string, so no changes needed there.
- Skipped issue #124 ("Allow players to identify which fief a player is in") this cycle — it's a larger feature addition (new lookup path in `InfoCommand`/`PersistentData`) rather than a same-batch fix; deferring to keep this PR small and focused per the early-cycle low-risk bias.

Closes #147

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
