### PR TITLE
Add /fi whois command to identify a player's fief

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - `/fi rename "new name"` command allowing fief owners to rename their fief (`fiefs.rename`)
+- `/fi whois <player>` command allowing players to check which fief a given player is a member of (`fiefs.whois`)
 
 ### Fixed
 - `/fi kick` refused to kick any member with "That player is not in your fief." — the target's fief

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -22,3 +22,4 @@ All commands use `/fi` or `/fiefs` as the base. Fiefs requires Medieval Factions
 | `/fi checkclaim` | Check which fief owns the chunk you are standing in. | `fiefs.checkclaim` |
 | `/fi flags` | View and alter your fief's configuration flags. | `fiefs.flags` |
 | `/fi config` | View and alter plugin config options. | `fiefs.config` |
+| `/fi whois <player>` | Check which fief a player is a member of. | `fiefs.whois` |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -44,6 +44,7 @@ Fiefs is a Spigot plugin that adds a sub-faction territory system to Medieval Fa
 | `fiefs.checkclaim` | `true` | Check which fief owns a chunk. |
 | `fiefs.flags` | `true` | View and alter fief flags. |
 | `fiefs.config` | `op` | View and alter plugin config options. |
+| `fiefs.whois` | `true` | Check which fief a player is a member of. |
 
 ## Support
 

--- a/src/main/java/dansplugins/fiefs/Fiefs.java
+++ b/src/main/java/dansplugins/fiefs/Fiefs.java
@@ -176,7 +176,8 @@ public final class Fiefs extends PonderBukkitPlugin {
                 new MembersCommand(medievalFactionsIntegrator, persistentData),
                 new RenameCommand(medievalFactionsIntegrator, persistentData),
                 new TransferCommand(medievalFactionsIntegrator, persistentData),
-                new UnclaimCommand(medievalFactionsIntegrator, persistentData, chunkService)
+                new UnclaimCommand(medievalFactionsIntegrator, persistentData, chunkService),
+                new WhoisCommand(persistentData)
         ));
         commandService.initialize(commands, "That command wasn't found.");
     }

--- a/src/main/java/dansplugins/fiefs/commands/HelpCommand.java
+++ b/src/main/java/dansplugins/fiefs/commands/HelpCommand.java
@@ -72,6 +72,7 @@ public class HelpCommand extends AbstractPluginCommand {
         sender.sendMessage(ChatColor.AQUA + "/fi transfer - Transfer your fief to another player.");
         sender.sendMessage(ChatColor.AQUA + "/fi flags - View and alter your fief's configuration.");
         sender.sendMessage(ChatColor.AQUA + "/fi config - View and alter this plugin's config options.");
+        sender.sendMessage(ChatColor.AQUA + "/fi whois - Check which fief a player is a member of.");
     }
 
 }

--- a/src/main/java/dansplugins/fiefs/commands/WhoisCommand.java
+++ b/src/main/java/dansplugins/fiefs/commands/WhoisCommand.java
@@ -1,0 +1,56 @@
+package dansplugins.fiefs.commands;
+
+import dansplugins.fiefs.data.PersistentData;
+import dansplugins.fiefs.objects.Fief;
+import dansplugins.fiefs.utils.UUIDChecker;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.UUID;
+
+/**
+ * @author Daniel McCoy Stephenson
+ */
+public class WhoisCommand extends AbstractPluginCommand {
+    private final PersistentData persistentData;
+
+    public WhoisCommand(PersistentData persistentData) {
+        super(new ArrayList<>(Arrays.asList("whois")), new ArrayList<>(Arrays.asList("fiefs.whois")));
+        this.persistentData = persistentData;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender) {
+        sender.sendMessage(ChatColor.RED + "Usage: /fi whois (playerName)");
+        return false;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String[] args) {
+        if (args.length == 0) {
+            return execute(sender);
+        }
+
+        String targetName = args[0];
+
+        UUIDChecker uuidChecker = new UUIDChecker();
+        UUID targetUUID = uuidChecker.findUUIDBasedOnPlayerName(targetName);
+        if (targetUUID == null) {
+            sender.sendMessage(ChatColor.RED + "That player wasn't found.");
+            return false;
+        }
+
+        Fief targetsFief = persistentData.getFief(targetUUID);
+        if (targetsFief == null) {
+            sender.sendMessage(ChatColor.AQUA + targetName + " is not a member of a fief.");
+            return true;
+        }
+
+        sender.sendMessage(ChatColor.AQUA + targetName + " is a member of " + targetsFief.getName() + ".");
+        return true;
+    }
+}

--- a/src/main/java/dansplugins/fiefs/commands/WhoisCommand.java
+++ b/src/main/java/dansplugins/fiefs/commands/WhoisCommand.java
@@ -5,7 +5,6 @@ import dansplugins.fiefs.objects.Fief;
 import dansplugins.fiefs.utils.UUIDChecker;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
 import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
 
 import java.util.ArrayList;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -46,3 +46,5 @@ permissions:
     default: true
   fiefs.config:
     default: op
+  fiefs.whois:
+    default: true


### PR DESCRIPTION
## Summary
- Players had no way to check which fief another player is a member of — `/fi info <name>` only ever resolved `<name>` as a fief name, not a player name.
- Adds `/fi whois <player>` (permission `fiefs.whois`, default `true`) which resolves the target's UUID via `UUIDChecker` and looks up their fief membership via `PersistentData.getFief(UUID)` (same pattern `KickCommand` already uses for target lookups).
- Registers the command in `Fiefs.java`, adds the permission node to `plugin.yml`, documents it in `COMMANDS.md`, `USER_GUIDE.md`, and `HelpCommand`'s page 2, and records it in `CHANGELOG.md` under `[Unreleased]`.

Closes #124

## Test plan
- `mvn clean package` — PASS, produces a shaded `target/Fiefs-0.11.0-SNAPSHOT.jar` with no errors.
- No automated test suite exists in this repo yet. Manual server validation (not performed in this sandbox — no Bukkit test server available): build the JAR, drop it and a matching Medieval Factions 5.7.2 JAR into a test server's `plugins/`, join a faction, create a fief, and run `/fi whois <playerName>` for both a fief member and a non-member to confirm both branches report correctly.

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
