### PR TITLE
Add first JUnit test suite: characterization tests for Fief

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Windows:
 
     mvn clean package
 
-If you see `BUILD SUCCESS`, the project has built successfully. There are currently no automated unit tests in this repository.
+If you see `BUILD SUCCESS`, the project has built successfully. `mvn clean package` also runs the JUnit test suite under `src/test/`.
 
 ## Development
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.jupiter.version>5.10.2</junit.jupiter.version>
     </properties>
 
     <build>
@@ -26,6 +27,11 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -90,6 +96,12 @@
             <artifactId>ponder</artifactId>
             <version>1.1</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/test/java/dansplugins/fiefs/objects/FiefTest.java
+++ b/src/test/java/dansplugins/fiefs/objects/FiefTest.java
@@ -1,0 +1,162 @@
+package dansplugins.fiefs.objects;
+
+import dansplugins.fiefs.utils.Logger;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Characterization tests for {@link Fief}'s in-memory state and the save()/load()
+ * round trip. The Medieval Factions integrator and Bukkit types are not exercised
+ * here since {@link Fief}'s constructors and the methods under test don't call into them.
+ */
+class FiefTest {
+
+    private static final Logger NULL_LOGGER = new Logger(null);
+
+    private Fief newFief(UUID owner, String factionId) {
+        return new Fief(null, "Test Fief", owner, factionId, NULL_LOGGER);
+    }
+
+    @Test
+    void constructor_addsOwnerAsMember() {
+        UUID owner = UUID.randomUUID();
+        Fief fief = newFief(owner, "faction-1");
+
+        assertTrue(fief.isMember(owner));
+        assertEquals(1, fief.getNumMembers());
+    }
+
+    @Test
+    void constructor_initializesDefaultFlags() {
+        Fief fief = newFief(UUID.randomUUID(), "faction-1");
+
+        assertEquals(true, fief.getFlags().getBooleanValues().get("claimedLandProtected"));
+    }
+
+    @Test
+    void addMember_addsNewPlayer() {
+        Fief fief = newFief(UUID.randomUUID(), "faction-1");
+        UUID member = UUID.randomUUID();
+
+        fief.addMember(member);
+
+        assertTrue(fief.isMember(member));
+        assertEquals(2, fief.getNumMembers());
+    }
+
+    @Test
+    void addMember_doesNotDuplicateExistingMember() {
+        Fief fief = newFief(UUID.randomUUID(), "faction-1");
+        UUID member = UUID.randomUUID();
+
+        fief.addMember(member);
+        fief.addMember(member);
+
+        assertEquals(2, fief.getNumMembers());
+    }
+
+    @Test
+    void removeMember_removesExistingMember() {
+        Fief fief = newFief(UUID.randomUUID(), "faction-1");
+        UUID member = UUID.randomUUID();
+        fief.addMember(member);
+
+        fief.removeMember(member);
+
+        assertFalse(fief.isMember(member));
+    }
+
+    @Test
+    void removeMember_isNoOpForNonMember() {
+        Fief fief = newFief(UUID.randomUUID(), "faction-1");
+        int before = fief.getNumMembers();
+
+        fief.removeMember(UUID.randomUUID());
+
+        assertEquals(before, fief.getNumMembers());
+    }
+
+    @Test
+    void getMembers_returnsUnmodifiableSnapshot() {
+        Fief fief = newFief(UUID.randomUUID(), "faction-1");
+        List<UUID> members = fief.getMembers();
+
+        assertThrows(UnsupportedOperationException.class, () -> members.add(UUID.randomUUID()));
+    }
+
+    @Test
+    void invitePlayer_addsInvite() {
+        Fief fief = newFief(UUID.randomUUID(), "faction-1");
+        UUID invitee = UUID.randomUUID();
+
+        fief.invitePlayer(invitee);
+
+        assertTrue(fief.isInvited(invitee));
+    }
+
+    @Test
+    void invitePlayer_doesNotDuplicateExistingInvite() {
+        Fief fief = newFief(UUID.randomUUID(), "faction-1");
+        UUID invitee = UUID.randomUUID();
+
+        fief.invitePlayer(invitee);
+        fief.invitePlayer(invitee);
+
+        assertTrue(fief.isInvited(invitee));
+    }
+
+    @Test
+    void uninvitePlayer_removesInvite() {
+        Fief fief = newFief(UUID.randomUUID(), "faction-1");
+        UUID invitee = UUID.randomUUID();
+        fief.invitePlayer(invitee);
+
+        fief.uninvitePlayer(invitee);
+
+        assertFalse(fief.isInvited(invitee));
+    }
+
+    @Test
+    void equals_trueForSameOwnerNameAndFaction() {
+        UUID owner = UUID.randomUUID();
+        Fief a = newFief(owner, "faction-1");
+        Fief b = newFief(owner, "faction-1");
+
+        assertTrue(a.equals(b));
+    }
+
+    @Test
+    void equals_falseForDifferentFaction() {
+        UUID owner = UUID.randomUUID();
+        Fief a = newFief(owner, "faction-1");
+        Fief b = newFief(owner, "faction-2");
+
+        assertFalse(a.equals(b));
+    }
+
+    /**
+     * Pins a known bug (Dans-Plugins/Fiefs#150): the load-from-storage constructor calls
+     * load(fiefData) before assigning `flags`, so load() NPEs on `flags.setIntegerValues(...)`.
+     * This is the exact constructor StorageService.loadFiefs() uses on every plugin startup,
+     * so any server restart with saved fief data currently fails to load it.
+     * Once #150 is fixed, replace this with a real save()/load() round-trip assertion.
+     */
+    @Test
+    void loadingFromSaveData_currentlyThrowsNullPointerException_knownBugIssue150() {
+        UUID owner = UUID.randomUUID();
+        Fief original = newFief(owner, "faction-1");
+        original.setDescription("A cozy fief");
+
+        Map<String, String> saved = original.save();
+
+        assertThrows(NullPointerException.class, () -> new Fief(saved, null, NULL_LOGGER));
+    }
+}


### PR DESCRIPTION
## Summary

- No open issues or PRs existed at triage; the MF v5 migration is complete (`pom.xml` pins `com.dansplugins:medieval-factions:5.7.2`, no v4 class references remain) and a full documentation sweep (README/COMMANDS/USER_GUIDE/CONFIG/CHANGELOG/plugin.yml/copilot-instructions) found no drift. This cycle does Stage B (unit-test expansion) per the dev-loop's fallback work modes.
- Adds `junit-jupiter` (test scope) and `maven-surefire-plugin` to `pom.xml` — the project's first automated test dependency. This does not affect the shaded runtime artifact (test-scope only; verified below).
- Adds `src/test/java/dansplugins/fiefs/objects/FiefTest.java`, the first unit test suite, covering `Fief`'s membership (`addMember`/`removeMember`/`isMember`), invites (`invitePlayer`/`uninvitePlayer`/`isInvited`), `getMembers()` immutability, `equals()`, and default flag initialization — all pure logic with no existing coverage.
- **Bug found while writing the save()/load() round-trip test, filed as #150**: `Fief`'s load-from-storage constructor calls `load(fiefData)` *before* assigning `flags`, and `load()` immediately dereferences `flags.setIntegerValues(...)`, throwing `NullPointerException`. This is exactly the constructor `StorageService.loadFiefs()` uses on every plugin `onEnable()`, so **any server restart with existing fief data currently fails to load it**. Per the characterization-only rule for test-expansion cycles, this PR does not fix the bug — the relevant test (`loadingFromSaveData_currentlyThrowsNullPointerException_knownBugIssue150`) pins the current (buggy) behavior instead of asserting a clean round trip, and the fix is left to a separate cycle.

Closes: none (this is Stage B work, not issue-driven — see #150 for the bug found).

## Test plan

- `mvn clean test` — 13 tests, 0 failures, 0 errors.
- `mvn clean package` — shaded JAR builds cleanly (`target/Fiefs-0.11.0-SNAPSHOT.jar`).
- Verified the shaded JAR contains no `org.junit.jupiter`/`opentest4j`/`apiguardian` classes (test-scope dependency does not leak into the runtime artifact). The JAR does already bundle legacy `org/junit/*` (JUnit 3/4) classes pre-existing from the `ponder` compile-scope dependency — confirmed unrelated to this change by rebuilding against `origin/main` with the same test file present.

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
