### PR TITLE
Fix NullPointerException when loading fiefs from saved data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fiefs saved to `fiefs.json` failed to load on startup, throwing a `NullPointerException` during
   plugin enable — a fief's flags were read before they were initialized. Servers with existing fief
-  data could not start the plugin, and the failed load left in-memory data empty so the next save
-  wrote an empty `fiefs.json` over it
+  data could not start the plugin, and because the failed load left in-memory data empty, a
+  subsequent save could write an empty `fiefs.json` over it
 - `/fi kick` refused to kick any member with "That player is not in your fief." — the target's fief
   was looked up by fief name using the player's name instead of by their UUID
 - `/fi invite` no longer invites a player who already belongs to another fief; the "already in a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `/fi whois <player>` command allowing players to check which fief a given player is a member of (`fiefs.whois`)
 
 ### Fixed
+- Fiefs saved to `fiefs.json` failed to load on startup, throwing a `NullPointerException` during
+  plugin enable — a fief's flags were read before they were initialized. Servers with existing fief
+  data could not start the plugin, and the failed load left in-memory data empty so the next save
+  wrote an empty `fiefs.json` over it
 - `/fi kick` refused to kick any member with "That player is not in your fief." — the target's fief
   was looked up by fief name using the player's name instead of by their UUID
 - `/fi invite` no longer invites a player who already belongs to another fief; the "already in a

--- a/src/main/java/dansplugins/fiefs/objects/Fief.java
+++ b/src/main/java/dansplugins/fiefs/objects/Fief.java
@@ -43,8 +43,8 @@ public class Fief {
 
     public Fief(Map<String, String> fiefData, MedievalFactionsIntegrator medievalFactionsIntegrator, Logger logger) {
         this.medievalFactionsIntegrator = medievalFactionsIntegrator;
+        flags = new FiefFlags(logger); // must be assigned before load(), which populates it
         this.load(fiefData);
-        flags = new FiefFlags(logger);
     }
 
     public String getName() {

--- a/src/test/java/dansplugins/fiefs/objects/FiefTest.java
+++ b/src/test/java/dansplugins/fiefs/objects/FiefTest.java
@@ -3,10 +3,12 @@ package dansplugins.fiefs.objects;
 import dansplugins.fiefs.utils.Logger;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -143,20 +145,70 @@ class FiefTest {
     }
 
     /**
-     * Pins a known bug (Dans-Plugins/Fiefs#150): the load-from-storage constructor calls
-     * load(fiefData) before assigning `flags`, so load() NPEs on `flags.setIntegerValues(...)`.
-     * This is the exact constructor StorageService.loadFiefs() uses on every plugin startup,
-     * so any server restart with saved fief data currently fails to load it.
-     * Once #150 is fixed, replace this with a real save()/load() round-trip assertion.
+     * Regression guard for Dans-Plugins/Fiefs#150: the load-from-storage constructor used to call
+     * load(fiefData) before assigning `flags`, so load() NPE'd on `flags.setIntegerValues(...)`.
+     * This is the exact constructor StorageService.loadFiefs() uses on every plugin startup, so
+     * the defect meant any server restart with saved fief data failed to load it.
      */
     @Test
-    void loadingFromSaveData_currentlyThrowsNullPointerException_knownBugIssue150() {
+    void loadingFromSaveData_doesNotThrow() {
+        Map<String, String> saved = newFief(UUID.randomUUID(), "faction-1").save();
+
+        assertDoesNotThrow(() -> new Fief(saved, null, NULL_LOGGER));
+    }
+
+    @Test
+    void saveThenLoad_preservesScalarFields() {
         UUID owner = UUID.randomUUID();
         Fief original = newFief(owner, "faction-1");
         original.setDescription("A cozy fief");
 
-        Map<String, String> saved = original.save();
+        Fief loaded = new Fief(original.save(), null, NULL_LOGGER);
 
-        assertThrows(NullPointerException.class, () -> new Fief(saved, null, NULL_LOGGER));
+        assertEquals("Test Fief", loaded.getName());
+        assertEquals("A cozy fief", loaded.getDescription());
+        assertEquals(owner, loaded.getOwnerUUID());
+        assertEquals("faction-1", loaded.getFactionId());
+    }
+
+    @Test
+    void saveThenLoad_preservesMembers() {
+        UUID owner = UUID.randomUUID();
+        UUID member = UUID.randomUUID();
+        Fief original = newFief(owner, "faction-1");
+        original.addMember(member);
+
+        Fief loaded = new Fief(original.save(), null, NULL_LOGGER);
+
+        assertEquals(2, loaded.getNumMembers());
+        assertTrue(loaded.isMember(owner));
+        assertTrue(loaded.isMember(member));
+    }
+
+    @Test
+    void saveThenLoad_preservesFlagValues() {
+        Fief original = newFief(UUID.randomUUID(), "faction-1");
+        original.getFlags().getBooleanValues().put("claimedLandProtected", false);
+
+        Fief loaded = new Fief(original.save(), null, NULL_LOGGER);
+
+        assertEquals(false, loaded.getFlags().getBooleanValues().get("claimedLandProtected"));
+    }
+
+    /**
+     * Save data written before a flag existed has no entry for it; load() must fall back to the
+     * default via FiefFlags.loadMissingFlagsIfNecessary() rather than leaving it absent.
+     */
+    @Test
+    void loadingSaveDataWithoutFlagValues_fallsBackToDefaults() {
+        Map<String, String> saved = new HashMap<>(newFief(UUID.randomUUID(), "faction-1").save());
+        saved.remove("integerFlagValues");
+        saved.remove("booleanFlagValues");
+        saved.remove("doubleFlagValues");
+        saved.remove("stringFlagValues");
+
+        Fief loaded = new Fief(saved, null, NULL_LOGGER);
+
+        assertEquals(true, loaded.getFlags().getBooleanValues().get("claimedLandProtected"));
     }
 }


### PR DESCRIPTION
## Summary

- **Fixes a startup-breaking, data-destroying bug** (#150). `Fief`'s load-from-storage constructor called `this.load(fiefData)` *before* assigning the `flags` field, and `load()` immediately dereferences it (`flags.setIntegerValues(...)`). One-line fix: assign `flags` before `load()`.
- This is the exact constructor `StorageService.loadFiefs()` uses on every `onEnable()` (`StorageService.java:99`), reached from `Fiefs.onEnable()` (`Fiefs.java:56`) with no `try`/`catch` anywhere in the chain — so **any server with at least one saved fief threw an uncaught `NullPointerException` during plugin enable**.
- **Worse than #150 originally described:** `loadFiefs()` calls `persistentData.clearFiefs()` *before* constructing any `Fief`, so the failure leaves in-memory fief data empty. `save()` (`StorageService.java:46`) unconditionally serializes whatever is in memory, so the next save writes an empty `fiefs.json` over the real data. `loadClaimedChunks()` is never reached either, so `claimedChunks.json` is exposed the same way. That escalation is recorded in the CHANGELOG entry and filed separately as a storage-layer resilience issue — this PR fixes the root cause, not the storage layer.
- Replaces the characterization test that pinned the NPE (added in #151) with a real `save()`/`load()` round-trip suite: scalar fields, members, flag values, and the missing-flag-key default fallback.

## Test plan

- `mvn clean package` — **BUILD SUCCESS**, `Tests run: 17, Failures: 0, Errors: 0, Skipped: 0`, shaded JAR produced at `target/Fiefs-0.11.0-SNAPSHOT.jar`.
- **Regression guards verified empirically**, not by reasoning: `git stash push -- src/main/java/dansplugins/fiefs/objects/Fief.java`, then `mvn test` → `Tests run: 17, Failures: 1, Errors: 4` with all 5 new tests failing on `NullPointerException: ... because "this.flags" is null`. `git stash pop` → 17/17 green again.
- Manual server validation (recommended before release, since CI cannot run the plugin): build the JAR, drop it plus a Medieval Factions 5.7.2 JAR into a test server's `plugins/`, `/fi create` a fief, `/fi claim` a chunk, stop the server, confirm `plugins/Fiefs/fiefs.json` is non-empty, restart, and confirm the plugin enables with no NPE in console and `/fi info` still reports the fief and its claims.

### No-automated-coverage gap

The new tests cover `Fief`'s pure save/load logic directly, which is where the defect lived. They do **not** exercise `StorageService`'s file I/O or the Bukkit enable lifecycle — CI compiles and shades but never runs the plugin, so the end-to-end "restart preserves data" behavior is only confirmed by the manual step above.

## Deferred this cycle

The only other open issue at triage was #150 itself (now fixed); PR #151 was carried over from the previous cycle, independently verified, and merged before this branch was cut. Two findings surfaced during triage are filed as follow-up issues rather than folded in here — the storage-layer load-failure resilience gap (touches `StorageService.java`, a human-review-gated path, and is a distinct architectural concern) and an inert `fiefs.default` permission node.

Closes #150

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
