### PR TITLE
Add characterization tests for FiefFlags

### DIFF
--- a/src/test/java/dansplugins/fiefs/objects/FiefFlagsTest.java
+++ b/src/test/java/dansplugins/fiefs/objects/FiefFlagsTest.java
@@ -1,0 +1,154 @@
+package dansplugins.fiefs.objects;
+
+import dansplugins.fiefs.utils.Logger;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Characterization tests for {@link FiefFlags}'s flag storage and lookup logic.
+ * {@code setFlag(...)} and {@code sendFlagList(...)} are not exercised here since they
+ * require a live Bukkit {@code Player} to send messages to.
+ */
+class FiefFlagsTest {
+
+    /**
+     * {@link Logger#log(String)} dereferences its {@code Fiefs} plugin reference, which is
+     * null outside a running server. {@code getFlag(...)} always logs, so tests need a logger
+     * that no-ops instead of throwing.
+     */
+    private static final class NoOpLogger extends Logger {
+        NoOpLogger() {
+            super(null);
+        }
+
+        @Override
+        public void log(String message) {
+            // no-op: avoids dereferencing the null Fiefs plugin reference in tests
+        }
+    }
+
+    private FiefFlags newFlags() {
+        return new FiefFlags(new NoOpLogger());
+    }
+
+    @Test
+    void constructor_doesNotPopulateValuesUntilInitialized() {
+        FiefFlags flags = newFlags();
+
+        assertEquals(0, flags.getNumFlags());
+    }
+
+    @Test
+    void initializeFlagValues_setsClaimedLandProtectedDefaultTrue() {
+        FiefFlags flags = newFlags();
+
+        flags.initializeFlagValues();
+
+        assertEquals(true, flags.getBooleanValues().get("claimedLandProtected"));
+    }
+
+    @Test
+    void loadMissingFlagsIfNecessary_addsDefaultWhenAbsent() {
+        FiefFlags flags = newFlags();
+
+        flags.loadMissingFlagsIfNecessary();
+
+        assertEquals(true, flags.getBooleanValues().get("claimedLandProtected"));
+    }
+
+    @Test
+    void loadMissingFlagsIfNecessary_doesNotOverrideExistingValue() {
+        FiefFlags flags = newFlags();
+        flags.initializeFlagValues();
+        flags.getBooleanValues().put("claimedLandProtected", false);
+
+        flags.loadMissingFlagsIfNecessary();
+
+        assertEquals(false, flags.getBooleanValues().get("claimedLandProtected"));
+    }
+
+    @Test
+    void getFlag_returnsValueForKnownFlag() {
+        FiefFlags flags = newFlags();
+        flags.initializeFlagValues();
+
+        assertEquals(true, flags.getFlag("claimedLandProtected"));
+    }
+
+    @Test
+    void getFlag_returnsFalseForUnknownFlag() {
+        FiefFlags flags = newFlags();
+
+        assertEquals(false, flags.getFlag("notARealFlag"));
+    }
+
+    @Test
+    void getFlag_returnsNullWhenKnownFlagHasNoStoredValue() {
+        FiefFlags flags = newFlags();
+
+        // "claimedLandProtected" is a declared flag name, but initializeFlagValues()/
+        // loadMissingFlagsIfNecessary() haven't run, so no value map contains it yet.
+        assertNull(flags.getFlag("claimedLandProtected"));
+    }
+
+    @Test
+    void getNumFlags_reflectsBooleanValueCount() {
+        FiefFlags flags = newFlags();
+        assertEquals(0, flags.getNumFlags());
+
+        flags.initializeFlagValues();
+
+        assertEquals(1, flags.getNumFlags());
+    }
+
+    @Test
+    void integerValues_roundTripThroughGetterAndSetter() {
+        FiefFlags flags = newFlags();
+        HashMap<String, Integer> values = new HashMap<>();
+        values.put("someIntFlag", 42);
+
+        flags.setIntegerValues(values);
+
+        assertEquals(42, flags.getIntegerValues().get("someIntFlag"));
+    }
+
+    @Test
+    void doubleValues_roundTripThroughGetterAndSetter() {
+        FiefFlags flags = newFlags();
+        HashMap<String, Double> values = new HashMap<>();
+        values.put("someDoubleFlag", 3.14);
+
+        flags.setDoubleValues(values);
+
+        assertEquals(3.14, flags.getDoubleValues().get("someDoubleFlag"));
+    }
+
+    @Test
+    void stringValues_roundTripThroughGetterAndSetter() {
+        FiefFlags flags = newFlags();
+        HashMap<String, String> values = new HashMap<>();
+        values.put("someStringFlag", "hello");
+
+        flags.setStringValues(values);
+
+        assertEquals("hello", flags.getStringValues().get("someStringFlag"));
+    }
+
+    @Test
+    void booleanValues_roundTripThroughGetterAndSetter() {
+        FiefFlags flags = newFlags();
+        HashMap<String, Boolean> values = new HashMap<>();
+        values.put("someBooleanFlag", true);
+
+        flags.setBooleanValues(values);
+
+        assertTrue(flags.getBooleanValues().get("someBooleanFlag"));
+        assertFalse(flags.getBooleanValues().containsKey("claimedLandProtected"));
+    }
+}


### PR DESCRIPTION
## Summary
- Stage B (unit-test expansion) cycle. Both currently open issues (#153, #154) are explicitly human-gated — the filer flagged each as needing a design/policy decision before implementation, and both touch do-not-auto-merge paths (`plugin.yml`, `data/StorageService.java`/`PersistentData.java`). Deferring them; not implementing this cycle.
- Adds `FiefFlagsTest`, the first test coverage for `objects/FiefFlags.java` — the only class in `objects/` (alongside the already-tested `Fief`, `PersistentData`) with zero prior tests.
- Covers: default-value initialization (`initializeFlagValues`), missing-flag backfill on load (`loadMissingFlagsIfNecessary`, including the "existing value isn't overwritten" case), known/unknown-flag lookup (`getFlag`), the flag-count accessor (`getNumFlags`), and get/set round trips for each of the four value-type maps (int/double/string/boolean).
- `setFlag(...)` and `sendFlagList(...)` are intentionally left uncovered — both require a live Bukkit `Player` to send a message to, and the project has no mocking framework (Mockito) as a dependency yet.
- `getFlag(...)` unconditionally calls `Logger.log(...)`, which dereferences a null `Fiefs` plugin reference outside a running server (same hazard the existing `Fief`/`PersistentData` characterization tests sidestep by never calling logging code paths). Added a small `NoOpLogger` test subclass that overrides `log()` rather than pulling in a mocking dependency for this alone.

## Test plan
- [x] `mvn clean package` — BUILD SUCCESS, shaded JAR produced in `target/`.
- [x] `mvn test -Dtest=FiefFlagsTest` — 12/12 tests pass.
- Characterization only: no production code changed, no existing assertions altered.

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
