### PR TITLE
Register fiefs.default permission node in plugin.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `/fi whois <player>` command allowing players to check which fief a given player is a member of (`fiefs.whois`)
 
 ### Fixed
+- `fiefs.default`, the permission node `DefaultCommand` (bare `/fi`) declares, was missing from
+  `plugin.yml` and undocumented; it is now registered with `default: true` and listed alongside
+  every other command's permission node
 - Fiefs saved to `fiefs.json` failed to load on startup, throwing a `NullPointerException` during
   plugin enable — a fief's flags were read before they were initialized. Servers with existing fief
   data could not start the plugin, and because the failed load left in-memory data empty, a

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -4,6 +4,7 @@ All commands use `/fi` or `/fiefs` as the base. Fiefs requires Medieval Factions
 
 | Command | Description | Permission |
 |---------|-------------|------------|
+| `/fi` | View plugin version and info. | `fiefs.default` |
 | `/fi help {1\|2}` | View command list (2 pages). | `fiefs.help` |
 | `/fi list` | List the fiefs in your faction. | `fiefs.list` |
 | `/fi create` | Create a new fief in your faction. | `fiefs.create` |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -26,6 +26,7 @@ Fiefs is a Spigot plugin that adds a sub-faction territory system to Medieval Fa
 
 | Permission | Default | Description |
 |------------|---------|-------------|
+| `fiefs.default` | `true` | View plugin version and info (bare `/fi`). |
 | `fiefs.help` | `true` | View the help menu. |
 | `fiefs.list` | `true` | List fiefs. |
 | `fiefs.create` | `true` | Create a fief. |

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,6 +10,8 @@ commands:
   fi:
 
 permissions:
+  fiefs.default:
+    default: true
   fiefs.help:
     default: true
   fiefs.list:


### PR DESCRIPTION
## Summary
- `DefaultCommand` (the bare `/fi` with no args, printing plugin version/info) has always
  declared the permission node `fiefs.default` in its constructor, but that node was never
  added to `plugin.yml` — the one gap in an otherwise complete parallel series of 19
  declared command permissions.
- It's currently harmless because `DefaultCommand` bypasses the `CommandService` dispatcher
  entirely (`Fiefs.onCommand()` calls `execute(sender)` directly for zero-arg invocations), so
  the undeclared permission is never actually checked. But if that ever changes, Bukkit's
  fallback for an undeclared permission is OP-only, which would silently gate bare `/fi` for
  every non-op player.
- Declares `fiefs.default: default: true` in `plugin.yml` and documents it in `COMMANDS.md` and
  `USER_GUIDE.md`'s permission tables (which otherwise enumerate every node), plus a
  `CHANGELOG.md` entry under `[Unreleased]`.

This is option 1 from the issue (declare the node) rather than option 2 (drop it from the
constructor) — it keeps `DefaultCommand` consistent with every sibling command's
declare-in-constructor / declare-in-plugin.yml pattern and is the safer choice if bare `/fi`
is ever routed through the permission-checking dispatcher.

## Test plan
- `mvn clean package` — PASS, shaded JAR produced at `target/Fiefs-0.11.0-SNAPSHOT.jar`.
- This is a plugin.yml/doc-only change (no Java logic touched); no runtime server test needed
  beyond the build succeeding, since `DefaultCommand`'s behavior is unchanged — only its
  previously-undeclared permission node is now registered.

Closes #154

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
