### PR TITLE
Guard StorageService against saving after a failed load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   fief" check was looking the target up by fief name and never matched
 - `/fi desc`'s no-argument usage message now shows double quotes, matching the double-quote parsing
   the command actually requires
+- A load failure partway through `fiefs.json` or `claimedChunks.json` (a malformed entry or invalid
+  JSON) no longer leaves in-memory fief/claim data empty; the file is now parsed fully before
+  replacing the existing in-memory data, and saving is skipped until the file is fixed and the
+  server restarted, so a bad load can no longer overwrite good data on disk
 
 ## [0.11.0]
 

--- a/src/main/java/dansplugins/fiefs/services/StorageService.java
+++ b/src/main/java/dansplugins/fiefs/services/StorageService.java
@@ -35,6 +35,10 @@ public class StorageService {
     private final static Type LIST_MAP_TYPE = new TypeToken<ArrayList<HashMap<String, String>>>(){}.getType();
     private final Gson gson = new GsonBuilder().setPrettyPrinting().create();;
 
+    // Set false whenever a load fails to fully parse, so save() doesn't overwrite
+    // fiefs.json/claimedChunks.json with the empty or partial in-memory state (#153).
+    private boolean loadCompletedCleanly = true;
+
     public StorageService(ConfigService configService, Fiefs fiefs, PersistentData persistentData, Logger logger, MedievalFactionsIntegrator medievalFactionsIntegrator) {
         this.configService = configService;
         this.fiefs = fiefs;
@@ -44,6 +48,11 @@ public class StorageService {
     }
 
     public void save() {
+        if (!loadCompletedCleanly) {
+            System.out.println("ERROR: skipping save because the last load did not complete cleanly. " +
+                    "Fix " + FIEFS_FILE_NAME + "/" + CLAIMED_CHUNKS_FILE_NAME + " and restart to try again.");
+            return;
+        }
         saveFiefs();
         saveClaimedChunks();
         if (configService.hasBeenAltered()) {
@@ -52,8 +61,17 @@ public class StorageService {
     }
 
     public void load() {
+        loadCompletedCleanly = true;
         loadFiefs();
         loadClaimedChunks();
+    }
+
+    /**
+     * For tests: whether both load() calls this session parsed their files fully,
+     * without needing to reach into the private flag directly.
+     */
+    boolean isLoadCompletedCleanly() {
+        return loadCompletedCleanly;
     }
 
     private void saveFiefs() {
@@ -91,23 +109,54 @@ public class StorageService {
     }
 
     private void loadFiefs() {
+        applyFiefs(FILE_PATH + FIEFS_FILE_NAME);
+    }
+
+    private void loadClaimedChunks() {
+        applyClaimedChunks(FILE_PATH + CLAIMED_CHUNKS_FILE_NAME);
+    }
+
+    // Package-private so tests can exercise the parse-then-swap behavior directly.
+    // Reading the file and constructing every entry happen inside the same try block, so a
+    // malformed JSON file (not just a malformed entry, e.g. bad UUID) is caught the same way.
+    void applyFiefs(String filename) {
+        ArrayList<Fief> loaded = new ArrayList<>();
+        try {
+            ArrayList<HashMap<String, String>> data = loadDataFromFilename(filename);
+            for (Map<String, String> fiefData : data) {
+                loaded.add(new Fief(fiefData, medievalFactionsIntegrator, logger));
+            }
+        } catch (RuntimeException e) {
+            // Parse only into a local list first, so a bad entry can't leave persistentData
+            // partially cleared/repopulated (#153): either every entry loads, or none do.
+            loadCompletedCleanly = false;
+            System.out.println("ERROR: failed to load " + FIEFS_FILE_NAME + " cleanly, leaving existing " +
+                    "in-memory fief data untouched: " + e);
+            return;
+        }
+
         persistentData.clearFiefs();
-
-        ArrayList<HashMap<String, String>> data = loadDataFromFilename(FILE_PATH + FIEFS_FILE_NAME);
-
-        for (Map<String, String> fiefData : data){
-            Fief fief = new Fief(fiefData, medievalFactionsIntegrator, logger);
+        for (Fief fief : loaded) {
             persistentData.addFief(fief);
         }
     }
 
-    private void loadClaimedChunks() {
+    void applyClaimedChunks(String filename) {
+        ArrayList<ClaimedChunk> loaded = new ArrayList<>();
+        try {
+            ArrayList<HashMap<String, String>> data = loadDataFromFilename(filename);
+            for (Map<String, String> claimedChunkData : data) {
+                loaded.add(new ClaimedChunk(claimedChunkData));
+            }
+        } catch (RuntimeException e) {
+            loadCompletedCleanly = false;
+            System.out.println("ERROR: failed to load " + CLAIMED_CHUNKS_FILE_NAME + " cleanly, leaving existing " +
+                    "in-memory claimed chunk data untouched: " + e);
+            return;
+        }
+
         persistentData.clearClaimedChunks();
-
-        ArrayList<HashMap<String, String>> data = loadDataFromFilename(FILE_PATH + CLAIMED_CHUNKS_FILE_NAME);
-
-        for (Map<String, String> claimedChunkData : data){
-            ClaimedChunk claimedChunk = new ClaimedChunk(claimedChunkData);
+        for (ClaimedChunk claimedChunk : loaded) {
             persistentData.addChunk(claimedChunk);
         }
     }

--- a/src/test/java/dansplugins/fiefs/services/StorageServiceTest.java
+++ b/src/test/java/dansplugins/fiefs/services/StorageServiceTest.java
@@ -173,7 +173,7 @@ class StorageServiceTest {
     }
 
     @Test
-    void applyClaimedChunks_emptyFileLeavesPersistentDataEmptyAndClean() {
+    void applyClaimedChunks_missingFileLeavesPersistentDataEmptyAndClean() {
         PersistentData persistentData = new PersistentData(null);
         StorageService storageService = newStorageService(persistentData);
 

--- a/src/test/java/dansplugins/fiefs/services/StorageServiceTest.java
+++ b/src/test/java/dansplugins/fiefs/services/StorageServiceTest.java
@@ -1,0 +1,223 @@
+package dansplugins.fiefs.services;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import dansplugins.fiefs.data.PersistentData;
+import dansplugins.fiefs.objects.Fief;
+import dansplugins.fiefs.utils.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+/**
+ * Characterization tests for the Dans-Plugins/Fiefs#153 fix: a load that fails to parse
+ * fully must never clear/partially repopulate {@link PersistentData}, and must block
+ * {@link StorageService#save()} from truncating the on-disk files with an incomplete
+ * in-memory state. The Medieval Factions integrator and Bukkit types are not exercised
+ * for the fiefs path since {@link Fief}'s map constructor doesn't call into them.
+ */
+class StorageServiceTest {
+
+    private static final Logger NULL_LOGGER = new Logger(null);
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    // Bukkit always creates the top-level "plugins/" folder before onEnable() runs (it's
+    // where the server loads plugin jars from), so StorageService's single-level mkdir() of
+    // "plugins/Fiefs/" only ever needs to create the leaf. Recreate that guarantee here.
+    private static final Path PLUGINS_TOP_LEVEL_DIR = Path.of("./plugins/");
+    private static final Path PLUGINS_DIR = Path.of("./plugins/Fiefs/");
+
+    private Path tempFile;
+
+    @AfterEach
+    void cleanup() throws IOException {
+        if (tempFile != null) {
+            Files.deleteIfExists(tempFile);
+        }
+        deleteRecursively(PLUGINS_TOP_LEVEL_DIR);
+    }
+
+    private static void deleteRecursively(Path path) throws IOException {
+        if (!Files.exists(path)) {
+            return;
+        }
+        try (Stream<Path> walk = Files.walk(path)) {
+            walk.sorted(Comparator.reverseOrder()).forEach(p -> {
+                try {
+                    Files.delete(p);
+                } catch (IOException ignored) {
+                    // best-effort test cleanup
+                }
+            });
+        }
+    }
+
+    private StorageService newStorageService(PersistentData persistentData) {
+        return new StorageService(new ConfigService(null), null, persistentData, NULL_LOGGER, null);
+    }
+
+    private Fief newFief(String name) {
+        return new Fief(null, name, UUID.randomUUID(), "faction-1", NULL_LOGGER);
+    }
+
+    private Path writeJson(Object data) throws IOException {
+        tempFile = Files.createTempFile("fiefs-storage-test", ".json");
+        Files.write(tempFile, GSON.toJson(data).getBytes(StandardCharsets.UTF_8));
+        return tempFile;
+    }
+
+    @Test
+    void applyFiefs_populatesPersistentDataFromValidFile() throws IOException {
+        PersistentData persistentData = new PersistentData(null);
+        StorageService storageService = newStorageService(persistentData);
+        List<Map<String, String>> data = new ArrayList<>();
+        data.add(newFief("Testopia").save());
+        Path file = writeJson(data);
+
+        storageService.applyFiefs(file.toString());
+
+        assertEquals(1, persistentData.getFiefs().size());
+        assertEquals("Testopia", persistentData.getFiefs().get(0).getName());
+        assertTrue(storageService.isLoadCompletedCleanly());
+    }
+
+    @Test
+    void applyFiefs_missingFileLeavesPersistentDataEmptyButCountsAsClean() {
+        PersistentData persistentData = new PersistentData(null);
+        StorageService storageService = newStorageService(persistentData);
+
+        storageService.applyFiefs("./does-not-exist-" + UUID.randomUUID() + ".json");
+
+        assertEquals(0, persistentData.getFiefs().size());
+        assertTrue(storageService.isLoadCompletedCleanly());
+    }
+
+    /**
+     * Regression guard for #153: previously, {@code loadFiefs()} cleared persistentData
+     * before parsing, so a bad entry (e.g. the unguarded {@code UUID.fromString(...)} in
+     * {@code Fief.load()}) left the in-memory state permanently empty instead of intact.
+     */
+    @Test
+    void applyFiefs_malformedEntryDoesNotClearOrPartiallyPopulatePersistentData() throws IOException {
+        PersistentData persistentData = new PersistentData(null);
+        Fief existing = newFief("Preexisting");
+        persistentData.addFief(existing);
+        StorageService storageService = newStorageService(persistentData);
+
+        List<Map<String, String>> data = new ArrayList<>();
+        data.add(newFief("Good").save());
+        Map<String, String> corrupted = newFief("Corrupted").save();
+        corrupted.put("ownerUUID", GSON.toJson("not-a-uuid"));
+        data.add(corrupted);
+        Path file = writeJson(data);
+
+        storageService.applyFiefs(file.toString());
+
+        // Both the pre-existing fief and the well-formed "Good" entry that came before the bad
+        // one in the file must survive untouched: the load is all-or-nothing, not partial.
+        assertEquals(1, persistentData.getFiefs().size());
+        assertEquals(existing, persistentData.getFiefs().get(0));
+        assertFalse(storageService.isLoadCompletedCleanly());
+    }
+
+    @Test
+    void applyFiefs_malformedJsonDoesNotClearPersistentData() throws IOException {
+        PersistentData persistentData = new PersistentData(null);
+        Fief existing = newFief("Preexisting");
+        persistentData.addFief(existing);
+        StorageService storageService = newStorageService(persistentData);
+        tempFile = Files.createTempFile("fiefs-storage-test", ".json");
+        Files.write(tempFile, "{ not valid json [".getBytes(StandardCharsets.UTF_8));
+
+        storageService.applyFiefs(tempFile.toString());
+
+        assertEquals(1, persistentData.getFiefs().size());
+        assertFalse(storageService.isLoadCompletedCleanly());
+    }
+
+    /**
+     * {@link dansplugins.fiefs.objects.ClaimedChunk}'s map constructor dereferences Bukkit's
+     * server, which is unavailable outside a running plugin and so always throws here. That
+     * exercises the same all-or-nothing guard a real malformed claimed-chunk entry would hit
+     * at runtime; the happy path is Bukkit-coupled and is instead covered by manual server
+     * validation (see PR description).
+     */
+    @Test
+    void applyClaimedChunks_entryConstructionFailureDoesNotClearPersistentData() throws IOException {
+        PersistentData persistentData = new PersistentData(null);
+        StorageService storageService = newStorageService(persistentData);
+        List<Map<String, String>> data = new ArrayList<>();
+        Map<String, String> chunkData = newFief("Testopia").save(); // any map shape triggers ClaimedChunk.load()
+        data.add(chunkData);
+        Path file = writeJson(data);
+
+        storageService.applyClaimedChunks(file.toString());
+
+        assertEquals(0, persistentData.getNumChunks());
+        assertFalse(storageService.isLoadCompletedCleanly());
+    }
+
+    @Test
+    void applyClaimedChunks_emptyFileLeavesPersistentDataEmptyAndClean() {
+        PersistentData persistentData = new PersistentData(null);
+        StorageService storageService = newStorageService(persistentData);
+
+        storageService.applyClaimedChunks("./does-not-exist-" + UUID.randomUUID() + ".json");
+
+        assertEquals(0, persistentData.getNumChunks());
+        assertTrue(storageService.isLoadCompletedCleanly());
+    }
+
+    /**
+     * Regression guard for #153: previously {@code save()} unconditionally serialized
+     * whatever was in memory, so a failed load got written straight over fiefs.json.
+     */
+    @Test
+    void save_skipsWritingWhenLoadDidNotCompleteCleanly() throws IOException {
+        assumeFalse(Files.exists(PLUGINS_DIR), "test expects no pre-existing ./plugins/Fiefs/ directory");
+
+        PersistentData persistentData = new PersistentData(null);
+        StorageService storageService = newStorageService(persistentData);
+        Map<String, String> corrupted = newFief("Corrupted").save();
+        corrupted.put("ownerUUID", GSON.toJson("not-a-uuid"));
+        List<Map<String, String>> data = new ArrayList<>();
+        data.add(corrupted);
+        Path file = writeJson(data);
+        storageService.applyFiefs(file.toString());
+        assertFalse(storageService.isLoadCompletedCleanly());
+
+        assertDoesNotThrow(storageService::save);
+
+        assertFalse(Files.exists(PLUGINS_DIR), "save() must not write ./plugins/Fiefs/ after an incomplete load");
+    }
+
+    @Test
+    void save_writesNormallyWhenLoadCompletedCleanly() throws IOException {
+        assumeFalse(Files.exists(PLUGINS_DIR), "test expects no pre-existing ./plugins/Fiefs/ directory");
+        Files.createDirectories(PLUGINS_TOP_LEVEL_DIR);
+
+        PersistentData persistentData = new PersistentData(null);
+        persistentData.addFief(newFief("Testopia"));
+        StorageService storageService = newStorageService(persistentData);
+        assertTrue(storageService.isLoadCompletedCleanly());
+
+        storageService.save();
+
+        assertTrue(Files.exists(PLUGINS_DIR.resolve("fiefs.json")));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes Dans-Plugins/Fiefs#153: a load failure partway through `fiefs.json`/`claimedChunks.json`
(e.g. a malformed UUID, hand-edited/truncated JSON) used to clear the in-memory fief/claim
collections *before* parsing could fail, and `save()` had no guard against writing that emptied
state back out — turning a load failure into permanent on-disk data loss.

- `StorageService.applyFiefs()` / `applyClaimedChunks()` now parse the whole file into a local
  list first; `persistentData` is only cleared and repopulated once parsing succeeds completely.
  A bad entry (or malformed JSON) leaves the existing in-memory state untouched instead of
  partially wiping it.
- `save()` now refuses to run at all if the last `load()` didn't complete cleanly, and logs why,
  so an autosave or shutdown save can't overwrite good on-disk data with an incomplete in-memory
  state. It's re-armed the next time `load()` runs.
- `CHANGELOG.md` updated under `[Unreleased]`.

No public API, command, permission node, or config key changed — this is internal to
`StorageService`.

<!-- gardener-tend-dispatch -->

## Test plan

- `mvn clean package`: **PASS** (55 tests, 0 failures).
- Added `StorageServiceTest` (8 new tests) covering:
  - a valid file populates `persistentData` and reports the load as clean
  - a missing file (normal first-run case) leaves it empty and still reports clean
  - a malformed entry (invalid UUID, reproducing the exact `Fief.load()` failure mode from #153)
    leaves pre-existing in-memory data untouched and marks the load unclean
  - malformed/invalid JSON is handled the same way
  - `save()` after an unclean load does not throw and does not write `./plugins/Fiefs/` at all
  - `save()` after a clean load writes normally
  - the same all-or-nothing guard for `applyClaimedChunks()` (the happy path there needs a live
    Bukkit server since `ClaimedChunk.load()` calls `Bukkit.getServer()`, so it's not unit-testable
    here — see note below)
- **Regression check (empirical):** stashed the `StorageService.java` fix and reran
  `StorageServiceTest` — it fails to *compile* (the new methods it exercises don't exist yet on
  `main`), i.e. the tests are structurally coupled to the fix, not passing coincidentally.
  Restored the fix and confirmed all 55 tests pass again.
- **Not unit-tested / manual validation still needed:** the claimed-chunks happy path
  (`ClaimedChunk`'s map constructor touches live Bukkit `World`/`Chunk` objects). To validate at
  runtime: build the shaded jar, drop it plus a Medieval Factions 5.7.2 jar into a test server's
  `plugins/`, claim a chunk with `/fi claim`, restart the server, and confirm the claim persists
  and `claimedChunks.json` round-trips correctly.

Closes #153

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
