### PR TITLE
Harden StorageService against two filesystem edge cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 target/
+# StorageServiceTest writes real save files under ./plugins/Fiefs/ and cleans them up
+# best-effort; a failing test can leave the directory behind, so never commit it.
+plugins/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   JSON) no longer leaves in-memory fief/claim data empty; the file is now parsed fully before
   replacing the existing in-memory data, and saving is skipped until the file is fixed and the
   server restarted, so a bad load can no longer overwrite good data on disk
+- A zero-byte `fiefs.json` or `claimedChunks.json` — which a crash or kill during the shutdown save
+  can leave behind — was treated as a corrupt file, which disabled saving for the whole session and
+  silently discarded every fief created or changed during it. An empty save file now loads as "no
+  data", the same as a missing one, and leaves saving enabled
+- The `./plugins/Fiefs/` save directory is now created with `mkdirs()` rather than `mkdir()`, so the
+  save no longer fails silently in environments where `./plugins/` does not already exist
 
 ## [0.11.0]
 

--- a/src/main/java/dansplugins/fiefs/services/StorageService.java
+++ b/src/main/java/dansplugins/fiefs/services/StorageService.java
@@ -97,7 +97,9 @@ public class StorageService {
     private void writeOutFiles(List<Map<String, String>> saveData, String fileName) {
         try {
             File parentFolder = new File(FILE_PATH);
-            parentFolder.mkdir();
+            // mkdirs(), not mkdir(): mkdir() only creates the leaf, so it fails silently when
+            // "./plugins/" itself is absent and the createNewFile() below then throws (#159).
+            parentFolder.mkdirs();
             File file = new File(FILE_PATH + fileName);
             file.createNewFile();
             OutputStreamWriter outputStreamWriter = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8);
@@ -165,7 +167,15 @@ public class StorageService {
         try{
             Gson gson = new GsonBuilder().setPrettyPrinting().create();;
             JsonReader reader = new JsonReader(new InputStreamReader(new FileInputStream(filename), StandardCharsets.UTF_8));
-            return gson.fromJson(reader, LIST_MAP_TYPE);
+            ArrayList<HashMap<String, String>> data = gson.fromJson(reader, LIST_MAP_TYPE);
+            // Gson yields null for a zero-byte file, which a crash mid-save can leave behind
+            // (FileOutputStream truncates before writing). An empty file is no data, not corrupt
+            // data, so treat it like a missing file rather than failing the load and blocking
+            // every subsequent save for the session (#160).
+            if (data == null) {
+                return new ArrayList<>();
+            }
+            return data;
         } catch (FileNotFoundException e) {
             // Fail silently because this can actually happen in normal use
         }

--- a/src/test/java/dansplugins/fiefs/services/StorageServiceTest.java
+++ b/src/test/java/dansplugins/fiefs/services/StorageServiceTest.java
@@ -36,9 +36,10 @@ class StorageServiceTest {
 
     private static final Logger NULL_LOGGER = new Logger(null);
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
-    // Bukkit always creates the top-level "plugins/" folder before onEnable() runs (it's
-    // where the server loads plugin jars from), so StorageService's single-level mkdir() of
-    // "plugins/Fiefs/" only ever needs to create the leaf. Recreate that guarantee here.
+    // In a real Bukkit deployment "plugins/" always exists before onEnable() runs (it's where the
+    // server loads plugin jars from), but StorageService must not depend on that: since #159 it
+    // creates the whole path with mkdirs(), so these tests deliberately start with no "plugins/"
+    // at all and delete it again afterwards.
     private static final Path PLUGINS_TOP_LEVEL_DIR = Path.of("./plugins/");
     private static final Path PLUGINS_DIR = Path.of("./plugins/Fiefs/");
 
@@ -135,6 +136,58 @@ class StorageServiceTest {
         assertFalse(storageService.isLoadCompletedCleanly());
     }
 
+    /**
+     * Regression guard for #160: a crash between {@code FileOutputStream}'s truncate and the write
+     * completing leaves a zero-byte save file. Gson parses that to {@code null}, which used to NPE
+     * inside the load and set {@code loadCompletedCleanly} false — silently disabling every save
+     * for the rest of the session. An empty file is no data, so it must load like a missing one.
+     */
+    @Test
+    void applyFiefs_emptyFileLeavesPersistentDataEmptyButCountsAsClean() throws IOException {
+        PersistentData persistentData = new PersistentData(null);
+        StorageService storageService = newStorageService(persistentData);
+        tempFile = Files.createTempFile("fiefs-storage-test", ".json");
+        assertEquals(0, Files.size(tempFile), "test expects a zero-byte file");
+
+        storageService.applyFiefs(tempFile.toString());
+
+        assertEquals(0, persistentData.getFiefs().size());
+        assertTrue(storageService.isLoadCompletedCleanly());
+    }
+
+    @Test
+    void applyClaimedChunks_emptyFileLeavesPersistentDataEmptyButCountsAsClean() throws IOException {
+        PersistentData persistentData = new PersistentData(null);
+        StorageService storageService = newStorageService(persistentData);
+        tempFile = Files.createTempFile("fiefs-storage-test", ".json");
+        assertEquals(0, Files.size(tempFile), "test expects a zero-byte file");
+
+        storageService.applyClaimedChunks(tempFile.toString());
+
+        assertEquals(0, persistentData.getNumChunks());
+        assertTrue(storageService.isLoadCompletedCleanly());
+    }
+
+    /**
+     * The other half of #160: an empty file must not just load cleanly, it must leave saving
+     * enabled, so the fiefs created during that session actually reach disk at shutdown.
+     */
+    @Test
+    void save_stillWritesAfterLoadingAnEmptyFile() throws IOException {
+        assumeFalse(Files.exists(PLUGINS_TOP_LEVEL_DIR), "test expects no pre-existing ./plugins/ directory");
+
+        PersistentData persistentData = new PersistentData(null);
+        StorageService storageService = newStorageService(persistentData);
+        tempFile = Files.createTempFile("fiefs-storage-test", ".json");
+        storageService.applyFiefs(tempFile.toString());
+        persistentData.addFief(newFief("CreatedAfterEmptyLoad"));
+
+        storageService.save();
+
+        assertTrue(Files.exists(PLUGINS_DIR.resolve("fiefs.json")),
+                "an empty save file must not disable saving for the session");
+    }
+
     @Test
     void applyFiefs_malformedJsonDoesNotClearPersistentData() throws IOException {
         PersistentData persistentData = new PersistentData(null);
@@ -206,10 +259,16 @@ class StorageServiceTest {
         assertFalse(Files.exists(PLUGINS_DIR), "save() must not write ./plugins/Fiefs/ after an incomplete load");
     }
 
+    /**
+     * Doubles as the regression guard for #159: no {@code ./plugins/} directory is created up
+     * front, so this only passes if {@code writeOutFiles()} builds the full path with
+     * {@code mkdirs()}. With the old single-level {@code mkdir()} the directory creation failed
+     * silently, {@code createNewFile()} threw {@code IOException: No such file or directory}, and
+     * the save was swallowed — leaving no {@code fiefs.json} behind.
+     */
     @Test
     void save_writesNormallyWhenLoadCompletedCleanly() throws IOException {
-        assumeFalse(Files.exists(PLUGINS_DIR), "test expects no pre-existing ./plugins/Fiefs/ directory");
-        Files.createDirectories(PLUGINS_TOP_LEVEL_DIR);
+        assumeFalse(Files.exists(PLUGINS_TOP_LEVEL_DIR), "test expects no pre-existing ./plugins/ directory");
 
         PersistentData persistentData = new PersistentData(null);
         persistentData.addFief(newFief("Testopia"));


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

Two independent filesystem edge cases in `StorageService`, both of which end in a save that silently does nothing.

## Summary

**#159 — `mkdir()` only creates the leaf directory.** `writeOutFiles()` built `./plugins/Fiefs/` with `parentFolder.mkdir()`, which returns `false` without throwing when `./plugins/` itself is absent. The following `file.createNewFile()` then threw `IOException: No such file or directory`, which the method catches and only prints to stdout — so the save was swallowed. Now uses `mkdirs()`.

**#160 — a zero-byte save file disabled saving for the whole session.** `loadDataFromFilename()` returned Gson's result directly, and Gson yields `null` for a zero-byte file. `applyFiefs()` / `applyClaimedChunks()` then NPE'd iterating it; the #153 guard caught that as a corrupt-file load and set `loadCompletedCleanly = false`, which makes `save()` a no-op for the rest of the server session. Every fief created or changed that session was then discarded at shutdown, with only a `System.out` line as warning.

That zero-byte file is reachable in normal operation: `writeOutFiles()` opens the file with `new FileOutputStream(file)`, which truncates to zero before any bytes are written, so a crash or kill during the shutdown save leaves it empty. An empty file is *no data*, not *corrupt data*, so it now loads like a missing file and leaves saving enabled.

## Data safety

Neither change can drop, overwrite, or corrupt existing persisted data — both are strictly-more-robust: `mkdirs()` creates a superset of what `mkdir()` created, and the null-to-empty-list conversion only affects a file that by definition holds no entries. The #153/#158 guard against overwriting good data with a partial load is untouched and still covered by its existing tests.

## Test plan

`mvn clean package` — PASS, shaded jar produced at `target/Fiefs-0.11.0-SNAPSHOT.jar`. `StorageServiceTest`: 11 tests, 0 failures, 0 skipped.

Three new tests plus one repurposed existing test guard these fixes:

- `applyFiefs_emptyFileLeavesPersistentDataEmptyButCountsAsClean` / `applyClaimedChunks_...` — a zero-byte file loads clean.
- `save_stillWritesAfterLoadingAnEmptyFile` — the other half of #160: saving stays enabled afterwards, so a fief created after an empty load actually reaches disk.
- `save_writesNormallyWhenLoadCompletedCleanly` no longer pre-creates `./plugins/`, so it now exercises and guards the `mkdirs()` fix. (It previously created that directory by hand specifically to work around the `mkdir()` limitation.)

**Empirical FAIL→PASS check** (rather than reasoning about it): with `StorageService.java` stashed and the tests left in place, exactly those 4 tests fail — `save_writesNormallyWhenLoadCompletedCleanly`, `save_stillWritesAfterLoadingAnEmptyFile`, `applyFiefs_emptyFileLeavesPersistentDataEmptyButCountsAsClean`, `applyClaimedChunks_emptyFileLeavesPersistentDataEmptyButCountsAsClean`. Restoring the fix returns all 11 to green.

### Manual server validation

The build compiles and shades but never runs the plugin, so CI cannot execute the persistence paths themselves. Recommended checks with the jar plus a Medieval Factions 5.7.2 jar on a test server:

1. **#160 happy path:** with existing fiefs, stop the server, truncate `plugins/Fiefs/fiefs.json` to 0 bytes (`: > fiefs.json`), start the server. Expect no load error in console. Create a fief with `/fi create`, stop the server, confirm the new fief is present in `fiefs.json` — on `main` the file stays empty and the fief is lost.
2. **No regression on the guard:** put deliberately malformed JSON in `fiefs.json`, start, confirm the console still reports the load failure and that a subsequent save is still skipped (existing #153 behavior must be unchanged).
3. **Normal round-trip:** create/claim/disband as usual, restart, confirm state persists.

#159 itself is not reproducible on a real Bukkit server, where `plugins/` always exists before `onEnable()` — it surfaces only in from-scratch environments such as the test suite. Step 3 confirms it causes no regression to the normal path.

Closes #159
Closes #160

---

Full open backlog at triage was exactly these two issues (#159 was open; #160 was filed during this cycle's triage after empirically confirming it against `main`), so nothing was deferred this cycle.


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
