### PR TITLE
Treat an unreadable fiefs.json/claimedChunks.json as a failed load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   data", the same as a missing one, and leaves saving enabled
 - The `./plugins/Fiefs/` save directory is now created with `mkdirs()` rather than `mkdir()`, so the
   save no longer fails silently in environments where `./plugins/` does not already exist
+- An existing `fiefs.json` or `claimedChunks.json` that cannot be opened for reading (for example
+  after a permission or ownership change on the server's data directory) was previously treated the
+  same as a missing file, loading as "no fiefs/claims" and leaving saving enabled — so the next save
+  could overwrite real data with an empty file. It is now treated as a failed load, matching the
+  existing handling for a malformed file, and saving is skipped until the file is fixed
 
 ## [0.11.0]
 

--- a/src/main/java/dansplugins/fiefs/services/StorageService.java
+++ b/src/main/java/dansplugins/fiefs/services/StorageService.java
@@ -164,6 +164,14 @@ public class StorageService {
     }
 
     private ArrayList<HashMap<String, String>> loadDataFromFilename(String filename) {
+        // FileNotFoundException covers more than "missing": per the FileInputStream(String)
+        // contract it's also thrown when the path is a directory or otherwise can't be opened
+        // for reading (e.g. no read permission). Checking existence first lets the catch below
+        // tell "nothing to load" apart from "data is there but unreadable" (#162), instead of
+        // treating both as an empty, cleanly-loaded file.
+        if (!new File(filename).exists()) {
+            return new ArrayList<>();
+        }
         try{
             Gson gson = new GsonBuilder().setPrettyPrinting().create();;
             JsonReader reader = new JsonReader(new InputStreamReader(new FileInputStream(filename), StandardCharsets.UTF_8));
@@ -177,8 +185,10 @@ public class StorageService {
             }
             return data;
         } catch (FileNotFoundException e) {
-            // Fail silently because this can actually happen in normal use
+            // The file exists but couldn't be opened for reading. Surface this as an unclean
+            // load (caught by applyFiefs()/applyClaimedChunks() as a RuntimeException) instead
+            // of silently returning an empty list, so save() doesn't overwrite real on-disk data.
+            throw new UncheckedIOException(e);
         }
-        return new ArrayList<>();
     }
 }

--- a/src/test/java/dansplugins/fiefs/services/StorageServiceTest.java
+++ b/src/test/java/dansplugins/fiefs/services/StorageServiceTest.java
@@ -109,6 +109,28 @@ class StorageServiceTest {
     }
 
     /**
+     * Regression guard for #162: a path that exists but can't be opened for reading must not be
+     * treated the same as a genuinely missing file, or the next save() overwrites the real
+     * on-disk data with an empty list. A directory is used to trigger this deterministically:
+     * per the {@code FileInputStream(String)} contract it throws {@code FileNotFoundException}
+     * for "does not exist, is a directory, or otherwise can't be opened" alike, and unlike a
+     * chmod-based unreadable file, a directory can't be opened as a byte stream even by a
+     * process running as root, so this doesn't need a privilege-dependent skip.
+     */
+    @Test
+    void applyFiefs_pathThatCannotBeOpenedForReadingIsTreatedAsUncleanRatherThanEmpty() throws IOException {
+        tempFile = Files.createTempDirectory("fiefs-storage-test-dir");
+
+        PersistentData persistentData = new PersistentData(null);
+        StorageService storageService = newStorageService(persistentData);
+
+        storageService.applyFiefs(tempFile.toString());
+
+        assertEquals(0, persistentData.getFiefs().size());
+        assertFalse(storageService.isLoadCompletedCleanly());
+    }
+
+    /**
      * Regression guard for #153: previously, {@code loadFiefs()} cleared persistentData
      * before parsing, so a bad entry (e.g. the unguarded {@code UUID.fromString(...)} in
      * {@code Fief.load()}) left the in-memory state permanently empty instead of intact.


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

- `StorageService.loadDataFromFilename()` is changed so that a save file which exists but cannot be opened for reading (permission/ownership issue, or the path being a directory) is distinguished from a genuinely missing file. Existence is checked first; when the path exists but `FileInputStream` still throws `FileNotFoundException`, an `UncheckedIOException` is thrown instead of the failure being swallowed, so the existing "unclean load" handling in `applyFiefs()`/`applyClaimedChunks()` is triggered and `save()` is blocked from overwriting real on-disk data with an empty list.
- A regression test is added (`applyFiefs_pathThatCannotBeOpenedForReadingIsTreatedAsUncleanRatherThanEmpty`), using a directory path to trigger the "exists but unopenable" case deterministically, since a directory can't be opened as a byte stream regardless of process privilege (a chmod-based approach was considered but would self-skip when tests run as root, as they do in this sandbox).
- `CHANGELOG.md` is updated under `[Unreleased] / Fixed`.

Closes #162

## Test plan

- `mvn clean package` — PASS (all 59 tests pass, shaded jar produced in `target/`).
- Empirical regression check performed per the review rubric: the production fix was stashed (`git stash push -- src/main/.../StorageService.java`) with the new test kept in place; the new test was confirmed to **FAIL** (`expected: <false> but was: <true>`). The fix was then restored (`git stash pop`) and the test was confirmed to **PASS**.
- This is a pure data-layer change with no Bukkit/MF coupling, so it is fully covered by the automated test above; no manual server validation step is required.

---

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).