### PR TITLE
Close the fiefs.json/claimedChunks.json handles on every path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   same as a missing file, loading as "no fiefs/claims" and leaving saving enabled — so the next save
   could overwrite real data with an empty file. It is now treated as a failed load, matching the
   existing handling for a malformed file, and saving is skipped until the file is fixed
+- `fiefs.json` and `claimedChunks.json` are now closed as soon as they have been read or written.
+  The load left its reader open for the garbage collector to clean up, which on Windows kept the
+  file locked long enough for a later save to fail, and a save that threw part-way through left its
+  file open and unflushed
 
 ## [0.11.0]
 

--- a/src/main/java/dansplugins/fiefs/services/StorageService.java
+++ b/src/main/java/dansplugins/fiefs/services/StorageService.java
@@ -182,7 +182,7 @@ public class StorageService {
         // chain around it fails to construct.
         try (FileInputStream fileInputStream = new FileInputStream(filename);
              JsonReader reader = new JsonReader(new InputStreamReader(fileInputStream, StandardCharsets.UTF_8))) {
-            Gson gson = new GsonBuilder().setPrettyPrinting().create();;
+            Gson gson = new GsonBuilder().setPrettyPrinting().create();
             ArrayList<HashMap<String, String>> data = gson.fromJson(reader, LIST_MAP_TYPE);
             // Gson yields null for a zero-byte file, which a crash mid-save can leave behind
             // (FileOutputStream truncates before writing). An empty file is no data, not corrupt

--- a/src/main/java/dansplugins/fiefs/services/StorageService.java
+++ b/src/main/java/dansplugins/fiefs/services/StorageService.java
@@ -102,9 +102,12 @@ public class StorageService {
             parentFolder.mkdirs();
             File file = new File(FILE_PATH + fileName);
             file.createNewFile();
-            OutputStreamWriter outputStreamWriter = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8);
-            outputStreamWriter.write(gson.toJson(saveData));
-            outputStreamWriter.close();
+            // try-with-resources, not a trailing close(): with close() as the last statement of the
+            // try block it was skipped whenever the write threw, leaving the file both open and
+            // unflushed while the catch below only logged (#164).
+            try (OutputStreamWriter outputStreamWriter = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)) {
+                outputStreamWriter.write(gson.toJson(saveData));
+            }
         } catch(IOException e) {
             System.out.println("ERROR: " + e.toString());
         }
@@ -172,9 +175,14 @@ public class StorageService {
         if (!new File(filename).exists()) {
             return new ArrayList<>();
         }
-        try{
+        // try-with-resources on the stream itself as well as the reader wrapping it: the reader
+        // was previously never closed at all, leaving the descriptor open until the garbage
+        // collector got around to it, which on Windows keeps the file locked against the next
+        // save (#164). Listing the FileInputStream separately also releases it if the reader
+        // chain around it fails to construct.
+        try (FileInputStream fileInputStream = new FileInputStream(filename);
+             JsonReader reader = new JsonReader(new InputStreamReader(fileInputStream, StandardCharsets.UTF_8))) {
             Gson gson = new GsonBuilder().setPrettyPrinting().create();;
-            JsonReader reader = new JsonReader(new InputStreamReader(new FileInputStream(filename), StandardCharsets.UTF_8));
             ArrayList<HashMap<String, String>> data = gson.fromJson(reader, LIST_MAP_TYPE);
             // Gson yields null for a zero-byte file, which a crash mid-save can leave behind
             // (FileOutputStream truncates before writing). An empty file is no data, not corrupt
@@ -188,6 +196,11 @@ public class StorageService {
             // The file exists but couldn't be opened for reading. Surface this as an unclean
             // load (caught by applyFiefs()/applyClaimedChunks() as a RuntimeException) instead
             // of silently returning an empty list, so save() doesn't overwrite real on-disk data.
+            throw new UncheckedIOException(e);
+        } catch (IOException e) {
+            // Only reachable from closing the reader, since every read failure surfaces from Gson
+            // as a JsonIOException. Treated as an unclean load for the same reason as above: the
+            // file could not be read end-to-end, so its contents must not be overwritten.
             throw new UncheckedIOException(e);
         }
     }

--- a/src/test/java/dansplugins/fiefs/services/StorageServiceTest.java
+++ b/src/test/java/dansplugins/fiefs/services/StorageServiceTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Characterization tests for the Dans-Plugins/Fiefs#153 fix: a load that fails to parse
@@ -42,6 +43,7 @@ class StorageServiceTest {
     // at all and delete it again afterwards.
     private static final Path PLUGINS_TOP_LEVEL_DIR = Path.of("./plugins/");
     private static final Path PLUGINS_DIR = Path.of("./plugins/Fiefs/");
+    private static final Path PROC_SELF_FD = Path.of("/proc/self/fd");
 
     private Path tempFile;
 
@@ -245,6 +247,66 @@ class StorageServiceTest {
 
         assertEquals(0, persistentData.getNumChunks());
         assertFalse(storageService.isLoadCompletedCleanly());
+    }
+
+    /**
+     * Regression guard for #164: the reader chain opened by {@code loadDataFromFilename()} used to
+     * be left for the garbage collector's cleaner to close, so the descriptor stayed open after the
+     * load returned — on Windows that keeps the file locked against the next save. The open
+     * descriptors are read from {@code /proc/self/fd}, so this only runs where procfs is available.
+     */
+    @Test
+    void applyFiefs_closesTheFileAfterLoadingIt() throws IOException {
+        assumeTrue(Files.isDirectory(PROC_SELF_FD), "test needs /proc/self/fd to observe open descriptors");
+
+        PersistentData persistentData = new PersistentData(null);
+        StorageService storageService = newStorageService(persistentData);
+        List<Map<String, String>> data = new ArrayList<>();
+        data.add(newFief("Testopia").save());
+        Path file = writeJson(data);
+
+        storageService.applyFiefs(file.toString());
+
+        assertTrue(storageService.isLoadCompletedCleanly(), "test expects a clean load");
+        assertFalse(openDescriptorsFor(file), "the save file must not be left open after the load");
+    }
+
+    /**
+     * The same guard for the claimed-chunks path, which reaches {@code loadDataFromFilename()}
+     * through {@link StorageService#applyClaimedChunks(String)}. An empty file is used so the
+     * Bukkit-coupled {@link dansplugins.fiefs.objects.ClaimedChunk} constructor is never reached;
+     * the descriptor must be released either way.
+     */
+    @Test
+    void applyClaimedChunks_closesTheFileAfterLoadingIt() throws IOException {
+        assumeTrue(Files.isDirectory(PROC_SELF_FD), "test needs /proc/self/fd to observe open descriptors");
+
+        PersistentData persistentData = new PersistentData(null);
+        StorageService storageService = newStorageService(persistentData);
+        Path file = writeJson(new ArrayList<Map<String, String>>());
+
+        storageService.applyClaimedChunks(file.toString());
+
+        assertTrue(storageService.isLoadCompletedCleanly(), "test expects a clean load");
+        assertFalse(openDescriptorsFor(file), "the save file must not be left open after the load");
+    }
+
+    /**
+     * Whether this JVM still holds any descriptor pointing at the given file. Broken or vanished
+     * symlinks under /proc/self/fd are ignored: the directory is read concurrently with the JVM's
+     * own file activity, so entries can disappear between listing and resolving them.
+     */
+    private static boolean openDescriptorsFor(Path file) throws IOException {
+        Path target = file.toRealPath();
+        try (Stream<Path> descriptors = Files.list(PROC_SELF_FD)) {
+            return descriptors.anyMatch(descriptor -> {
+                try {
+                    return Files.readSymbolicLink(descriptor).equals(target);
+                } catch (IOException ignored) {
+                    return false;
+                }
+            });
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `loadDataFromFilename()` now opens its `FileInputStream`/`JsonReader` chain in a try-with-resources block. The reader was previously never closed on any path, so the descriptor stayed open until the garbage collector's cleaner reclaimed it; on Windows the lingering handle keeps `fiefs.json`/`claimedChunks.json` locked, and a subsequent save over the same file can fail with a sharing violation.
- `writeOutFiles()` now opens its `OutputStreamWriter` in a try-with-resources block. `close()` was the last statement inside the `try`, so it was skipped whenever `gson.toJson(...)` or `write(...)` threw, leaving a partially written file both open and unflushed while the `catch (IOException e)` block only logged.
- An `IOException` raised by closing the reader is treated as an unclean load, matching the handling introduced for #162: the file could not be read end-to-end, so its contents must not be overwritten by the next save. Every read failure from Gson itself already surfaced as a `JsonIOException` and is unaffected.
- The #162 (unopenable file, unclean load), #160 (zero-byte file, clean empty load), #159 (`mkdirs()`) and #153 (all-or-nothing parse) behaviors are preserved unchanged; their existing regression tests still pass.

## Test plan

- `mvn clean package` — PASS, shaded JAR produced at `target/Fiefs-0.11.0-SNAPSHOT.jar`.
- `mvn test` — PASS, 61 tests, 0 failures.
- Two regression tests were added to `StorageServiceTest`, covering the fief and claimed-chunk load paths. They assert that no descriptor under `/proc/self/fd` still points at the save file once the load has returned, and are skipped where procfs is unavailable. Both were confirmed to FAIL with the `StorageService.java` change stashed (`expected: <false> but was: <true>`) and to PASS with it applied.
- The write path is not covered by a new test: forcing `write()` to throw would require injecting a failing stream into a private method, and no deterministic failure injection exists at the current seam. That half of the change is a mechanical try-with-resources conversion with no behavior change on the success path, which the existing `save_writesNormallyWhenLoadCompletedCleanly` and `save_stillWritesAfterLoadingAnEmptyFile` tests exercise.
- Manual server validation is recommended before release, since CI compiles and shades but never runs the plugin: the shaded JAR plus a matching Medieval Factions 5.7.2 JAR should be dropped into a test server's `plugins/`, a fief created with `/fi create`, and the server restarted — `fiefs.json` must reload with the fief intact, and a second restart must save over the file without error.

Closes #164

## Notes

- `src/main/java/dansplugins/fiefs/services/StorageService.java` is a persistence path on this repository's do-not-auto-merge list, so this pull request is left open for human review rather than being merged automatically.
- No other open issue existed at triage time, so nothing was deferred this cycle.

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->