### PR TITLE
Add characterization tests for FiefsAPI and FI_Fief

### DIFF
--- a/src/test/java/dansplugins/fiefs/externalapi/FI_FiefTest.java
+++ b/src/test/java/dansplugins/fiefs/externalapi/FI_FiefTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
@@ -111,6 +110,6 @@ class FI_FiefTest {
         unprotectedFief.getFlags().getBooleanValues().put("claimedLandProtected", false);
 
         assertEquals(true, new FI_Fief(protectedFief).getFlag("claimedLandProtected"));
-        assertFalse((Boolean) new FI_Fief(unprotectedFief).getFlag("claimedLandProtected"));
+        assertEquals(false, new FI_Fief(unprotectedFief).getFlag("claimedLandProtected"));
     }
 }

--- a/src/test/java/dansplugins/fiefs/externalapi/FI_FiefTest.java
+++ b/src/test/java/dansplugins/fiefs/externalapi/FI_FiefTest.java
@@ -1,0 +1,116 @@
+package dansplugins.fiefs.externalapi;
+
+import dansplugins.fiefs.objects.Fief;
+import dansplugins.fiefs.utils.Logger;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Characterization tests for {@link FI_Fief}, the read-only view of a {@link Fief} handed to
+ * other plugins. Each accessor delegates to the wrapped fief, so what is pinned here is that
+ * the view stays in step with the fief behind it and what it reports for an unknown flag.
+ *
+ * {@code isMember(Player)} is not exercised: it needs a live Bukkit {@code Player}, and the
+ * membership check it delegates to is covered by {@code FiefTest}.
+ */
+class FI_FiefTest {
+
+    /**
+     * {@link Logger#log(String)} dereferences its {@code Fiefs} plugin reference, which is
+     * null outside a running server. {@code getFlag(...)} always logs, so tests need a logger
+     * that no-ops instead of throwing.
+     */
+    private static final class NoOpLogger extends Logger {
+        NoOpLogger() {
+            super(null);
+        }
+
+        @Override
+        public void log(String message) {
+            // no-op: avoids dereferencing the null Fiefs plugin reference in tests
+        }
+    }
+
+    private Fief newFief(String name, UUID owner) {
+        return new Fief(null, name, owner, "faction-1", new NoOpLogger());
+    }
+
+    @Test
+    void getName_returnsTheWrappedFiefsName() {
+        FI_Fief view = new FI_Fief(newFief("Testopia", UUID.randomUUID()));
+
+        assertEquals("Testopia", view.getName());
+    }
+
+    @Test
+    void getOwner_returnsTheWrappedFiefsOwnerUUID() {
+        UUID owner = UUID.randomUUID();
+
+        FI_Fief view = new FI_Fief(newFief("Testopia", owner));
+
+        assertEquals(owner, view.getOwner());
+    }
+
+    @Test
+    void getFlag_returnsTheDefaultValueOfAKnownFlag() {
+        FI_Fief view = new FI_Fief(newFief("Testopia", UUID.randomUUID()));
+
+        assertEquals(true, view.getFlag("claimedLandProtected"));
+    }
+
+    /**
+     * An unknown flag reports {@code false} rather than null, so a caller cannot tell it apart
+     * from a boolean flag that is genuinely set to false.
+     */
+    @Test
+    void getFlag_returnsFalseForAnUnknownFlag() {
+        FI_Fief view = new FI_Fief(newFief("Testopia", UUID.randomUUID()));
+
+        assertEquals(false, view.getFlag("noSuchFlag"));
+    }
+
+    /**
+     * A known flag with no stored value reports null, unlike an unknown flag, which reports false.
+     */
+    @Test
+    void getFlag_returnsNullWhenAKnownFlagHasNoStoredValue() {
+        Fief fief = newFief("Testopia", UUID.randomUUID());
+        fief.getFlags().getBooleanValues().remove("claimedLandProtected");
+
+        assertNull(new FI_Fief(fief).getFlag("claimedLandProtected"));
+    }
+
+    /**
+     * The view holds the fief itself rather than a copy of its state, so later changes to the
+     * fief are visible through a view handed out beforehand.
+     */
+    @Test
+    void accessors_reflectLaterChangesToTheWrappedFief() {
+        Fief fief = newFief("Testopia", UUID.randomUUID());
+        FI_Fief view = new FI_Fief(fief);
+        UUID newOwner = UUID.randomUUID();
+
+        fief.setName("Renamed");
+        fief.setOwnerUUID(newOwner);
+        fief.getFlags().getBooleanValues().put("claimedLandProtected", false);
+
+        assertEquals("Renamed", view.getName());
+        assertEquals(newOwner, view.getOwner());
+        assertEquals(false, view.getFlag("claimedLandProtected"));
+    }
+
+    @Test
+    void getFlag_readsTheFlagStateOfTheWrappedFiefRatherThanASharedDefault() {
+        Fief protectedFief = newFief("Testopia", UUID.randomUUID());
+        Fief unprotectedFief = newFief("Otherton", UUID.randomUUID());
+        unprotectedFief.getFlags().getBooleanValues().put("claimedLandProtected", false);
+
+        assertEquals(true, new FI_Fief(protectedFief).getFlag("claimedLandProtected"));
+        assertFalse((Boolean) new FI_Fief(unprotectedFief).getFlag("claimedLandProtected"));
+    }
+}

--- a/src/test/java/dansplugins/fiefs/externalapi/FiefsAPITest.java
+++ b/src/test/java/dansplugins/fiefs/externalapi/FiefsAPITest.java
@@ -1,0 +1,151 @@
+package dansplugins.fiefs.externalapi;
+
+import dansplugins.fiefs.data.PersistentData;
+import dansplugins.fiefs.objects.Fief;
+import dansplugins.fiefs.utils.Logger;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Characterization tests for {@link FiefsAPI}, the entry point other plugins call into.
+ * The lookups delegate to {@link PersistentData}, so what is pinned here is the wrapping
+ * behaviour of the boundary itself: which {@link Fief} each overload resolves to, and what
+ * is handed back when no fief matches.
+ *
+ * {@code getFief(Player)} is not exercised: it needs a live Bukkit {@code Player}, and the
+ * UUID overload covers the same {@link PersistentData} lookup. The Medieval Factions
+ * integrator is not exercised either, since none of the methods under test call into it.
+ */
+class FiefsAPITest {
+
+    private static final Logger NULL_LOGGER = new Logger(null);
+
+    private PersistentData newPersistentData() {
+        return new PersistentData(null);
+    }
+
+    private Fief newFief(String name, UUID owner, String factionId) {
+        return new Fief(null, name, owner, factionId, NULL_LOGGER);
+    }
+
+    @Test
+    void getFiefByName_wrapsTheMatchingFief() {
+        PersistentData persistentData = newPersistentData();
+        persistentData.addFief(newFief("Testopia", UUID.randomUUID(), "faction-1"));
+        FiefsAPI api = new FiefsAPI(persistentData);
+
+        FI_Fief wrapped = api.getFief("Testopia");
+
+        assertEquals("Testopia", wrapped.getName());
+    }
+
+    @Test
+    void getFiefByName_matchesCaseInsensitively() {
+        PersistentData persistentData = newPersistentData();
+        persistentData.addFief(newFief("Testopia", UUID.randomUUID(), "faction-1"));
+        FiefsAPI api = new FiefsAPI(persistentData);
+
+        FI_Fief wrapped = api.getFief("teSTopIA");
+
+        assertEquals("Testopia", wrapped.getName());
+    }
+
+    /**
+     * The unknown-name case does not surface as a null return: {@link PersistentData} returns
+     * null, and the API wraps that null in an {@link FI_Fief} regardless, so a caller's null
+     * check passes and the failure only appears on the first accessor call. Pinned as current
+     * behaviour, not endorsed as the right contract.
+     */
+    @Test
+    void getFiefByName_returnsNonNullWrapperAroundNullForUnknownName() {
+        FiefsAPI api = new FiefsAPI(newPersistentData());
+
+        FI_Fief wrapped = api.getFief("no-such-fief");
+
+        assertNotNull(wrapped);
+        assertThrows(NullPointerException.class, wrapped::getName);
+    }
+
+    @Test
+    void getFiefByPlayerUUID_wrapsTheFiefContainingThatMember() {
+        PersistentData persistentData = newPersistentData();
+        UUID owner = UUID.randomUUID();
+        UUID member = UUID.randomUUID();
+        Fief fief = newFief("Testopia", owner, "faction-1");
+        fief.addMember(member);
+        persistentData.addFief(fief);
+        persistentData.addFief(newFief("Otherton", UUID.randomUUID(), "faction-1"));
+        FiefsAPI api = new FiefsAPI(persistentData);
+
+        assertEquals("Testopia", api.getFief(member).getName());
+        assertEquals("Testopia", api.getFief(owner).getName());
+    }
+
+    @Test
+    void getFiefByPlayerUUID_returnsNonNullWrapperAroundNullWhenNoFiefContainsThePlayer() {
+        PersistentData persistentData = newPersistentData();
+        persistentData.addFief(newFief("Testopia", UUID.randomUUID(), "faction-1"));
+        FiefsAPI api = new FiefsAPI(persistentData);
+
+        FI_Fief wrapped = api.getFief(UUID.randomUUID());
+
+        assertNotNull(wrapped);
+        assertThrows(NullPointerException.class, wrapped::getName);
+    }
+
+    @Test
+    void getFiefsOfFaction_returnsOnlyTheFiefsOfThatFaction() {
+        PersistentData persistentData = newPersistentData();
+        persistentData.addFief(newFief("Testopia", UUID.randomUUID(), "faction-1"));
+        persistentData.addFief(newFief("Otherton", UUID.randomUUID(), "faction-2"));
+        persistentData.addFief(newFief("Thirdville", UUID.randomUUID(), "faction-1"));
+        FiefsAPI api = new FiefsAPI(persistentData);
+
+        ArrayList<FI_Fief> fiefs = api.getFiefsOfFaction("faction-1");
+
+        assertEquals(2, fiefs.size());
+        assertEquals("Testopia", fiefs.get(0).getName());
+        assertEquals("Thirdville", fiefs.get(1).getName());
+    }
+
+    @Test
+    void getFiefsOfFaction_returnsEmptyListForUnknownFaction() {
+        PersistentData persistentData = newPersistentData();
+        persistentData.addFief(newFief("Testopia", UUID.randomUUID(), "faction-1"));
+        FiefsAPI api = new FiefsAPI(persistentData);
+
+        assertTrue(api.getFiefsOfFaction("faction-99").isEmpty());
+    }
+
+    /**
+     * Faction ids are matched exactly, unlike fief names, which are matched case-insensitively.
+     */
+    @Test
+    void getFiefsOfFaction_matchesFactionIdCaseSensitively() {
+        PersistentData persistentData = newPersistentData();
+        persistentData.addFief(newFief("Testopia", UUID.randomUUID(), "faction-1"));
+        FiefsAPI api = new FiefsAPI(persistentData);
+
+        assertTrue(api.getFiefsOfFaction("FACTION-1").isEmpty());
+    }
+
+    /**
+     * Each call builds fresh wrappers, so wrappers cannot be compared by identity even when
+     * they stand for the same fief.
+     */
+    @Test
+    void getFief_returnsANewWrapperOnEachCall() {
+        PersistentData persistentData = newPersistentData();
+        persistentData.addFief(newFief("Testopia", UUID.randomUUID(), "faction-1"));
+        FiefsAPI api = new FiefsAPI(persistentData);
+
+        assertTrue(api.getFief("Testopia") != api.getFief("Testopia"));
+    }
+}

--- a/src/test/java/dansplugins/fiefs/externalapi/FiefsAPITest.java
+++ b/src/test/java/dansplugins/fiefs/externalapi/FiefsAPITest.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -146,6 +147,6 @@ class FiefsAPITest {
         persistentData.addFief(newFief("Testopia", UUID.randomUUID(), "faction-1"));
         FiefsAPI api = new FiefsAPI(persistentData);
 
-        assertTrue(api.getFief("Testopia") != api.getFief("Testopia"));
+        assertNotSame(api.getFief("Testopia"), api.getFief("Testopia"));
     }
 }


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

- Characterization tests were added for `src/main/java/dansplugins/fiefs/externalapi/`, which had no
  coverage. This is the boundary other plugins call into, and the one this repository holds for
  human review before merge because a regression there breaks every integration built on it.
- `FiefsAPITest` (9 tests) pins which fief each `getFief(...)` overload resolves to, the
  case-insensitive name match, what is handed back when nothing matches, that
  `getFiefsOfFaction(...)` returns one wrapper per fief of that faction and matches faction ids
  case-sensitively, and that a fresh wrapper is built on each call.
- `FI_FiefTest` (7 tests) pins that the accessors read through to the wrapped `Fief` rather than to
  a copy, and what `getFlag(...)` reports for a known flag, an unknown flag, and a known flag whose
  stored value has been removed.
- No production code was changed; `src/test/` is the only tree touched.

Two behaviours were documented rather than corrected, per the characterization rule that a test
cycle asserts current behaviour and files anything questionable separately:

- An unmatched `getFief(...)` returns a non-null `FI_Fief` wrapping null, so the failure surfaces
  as a `NullPointerException` from the first accessor rather than at the lookup. Filed as #171;
  fixing it changes a public API's contract and belongs to a maintainer-reviewed cycle.
- `FI_Fief.getFlag(...)` reports `false` for an unknown flag and `null` for a known flag with no
  stored value, so an unknown flag is indistinguishable from a boolean flag set to `false`. This
  matches what `FiefFlagsTest` already pins on the layer below and is asserted here as-is.

Conventions were followed from the neighbouring tests: JUnit 5 only, no mocking framework, no
Bukkit statics, and a `NoOpLogger` subclass copied from `FiefFlagsTest` for the paths that log.
`getFief(Player)` and `isMember(Player)` are not exercised — a live Bukkit `Player` would be
required, and the lookups behind both are reachable through the UUID-based paths.

## Test plan

- `mvn clean package` — BUILD SUCCESS, shaded JAR produced at
  `target/Fiefs-0.12.0-SNAPSHOT-8-8-2026.jar`.
- `mvn test` — 77 tests run, 0 failures, 0 errors, 0 skipped (61 previously existing, 16 added
  here: 9 in `FiefsAPITest`, 7 in `FI_FiefTest`).
- No manual server validation is required: nothing this pull request contains ships in the plugin,
  and no runtime behaviour is altered.

## Notes

No `CHANGELOG.md` entry was added. The changelog records user-visible changes, and a test-only
change is not one.

Backlog deferred this cycle, recorded for auditability:

- #168 (stray empty statements and the redundant local `Gson` in `StorageService`) — deferred on
  the reasoning in the issue itself: `StorageService.java` is on the do-not-auto-merge persistence
  path, so batching that cleanup with the next human-reviewed change to the file is preferable to
  spending a review cycle on a behaviour-neutral one-liner. Two further instances of the same
  pattern were found and recorded on that issue.
- #167 (dms-conventions alignment) — the sections that remain open all require either explicit
  maintainer authorization (`CLAUDE.md` is agent-loaded configuration), changes to
  `.github/workflows/` or `pom.xml` (both held for human review, and §6 additionally needs a
  decision about which Java version is intended), or repository administration access (§7).
- #171 — filed by this cycle and deliberately left for a maintainer-reviewed cycle, as above.

Closes #170

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

---

_drafted by Claude on behalf of Daniel Stephenson_