### PR TITLE
Remove stray empty statements and reuse StorageService's Gson field

### DIFF
--- a/src/main/java/dansplugins/fiefs/objects/ClaimedChunk.java
+++ b/src/main/java/dansplugins/fiefs/objects/ClaimedChunk.java
@@ -75,7 +75,7 @@ public class ClaimedChunk {
     }
 
     public Map<String, String> save() {
-            Gson gson = new GsonBuilder().setPrettyPrinting().create();;
+            Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
             Map<String, String> saveMap = new HashMap<>();
             saveMap.put("X", gson.toJson(chunk.getX()));

--- a/src/main/java/dansplugins/fiefs/objects/Fief.java
+++ b/src/main/java/dansplugins/fiefs/objects/Fief.java
@@ -146,7 +146,7 @@ public class Fief {
     }
 
     public Map<String, String> save() {
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();;
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
         Map<String, String> saveMap = new HashMap<>();
         saveMap.put("name", gson.toJson(name));

--- a/src/main/java/dansplugins/fiefs/services/StorageService.java
+++ b/src/main/java/dansplugins/fiefs/services/StorageService.java
@@ -33,7 +33,7 @@ public class StorageService {
     private final static String FIEFS_FILE_NAME = "fiefs.json";
     private final static String CLAIMED_CHUNKS_FILE_NAME = "claimedChunks.json";
     private final static Type LIST_MAP_TYPE = new TypeToken<ArrayList<HashMap<String, String>>>(){}.getType();
-    private final Gson gson = new GsonBuilder().setPrettyPrinting().create();;
+    private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
     // Set false whenever a load fails to fully parse, so save() doesn't overwrite
     // fiefs.json/claimedChunks.json with the empty or partial in-memory state (#153).
@@ -182,7 +182,6 @@ public class StorageService {
         // chain around it fails to construct.
         try (FileInputStream fileInputStream = new FileInputStream(filename);
              JsonReader reader = new JsonReader(new InputStreamReader(fileInputStream, StandardCharsets.UTF_8))) {
-            Gson gson = new GsonBuilder().setPrettyPrinting().create();;
             ArrayList<HashMap<String, String>> data = gson.fromJson(reader, LIST_MAP_TYPE);
             // Gson yields null for a zero-byte file, which a crash mid-save can leave behind
             // (FileOutputStream truncates before writing). An empty file is no data, not corrupt


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

- The four `new GsonBuilder().setPrettyPrinting().create();;` lines recorded in #168 have had their
  trailing empty statement removed: `services/StorageService.java:36`, `services/StorageService.java:185`,
  `objects/Fief.java:149` and `objects/ClaimedChunk.java:78`. `grep -rn ';;' src/main/java --include=*.java`
  now returns nothing.
- `StorageService.loadDataFromFilename()` no longer constructs its own `Gson`. The class already holds
  an identically configured `gson` field, which is used directly instead.

Every change here is behaviour-neutral: an empty statement compiles to nothing, and the removed local
`Gson` was configured exactly as the field that replaces it (`setPrettyPrinting()`, which affects
serialization only and is not consulted when reading).

## What was deliberately left out

The redundant `Gson` construction inside `Fief.save()`, `ClaimedChunk.save()` and `ClaimedChunk.load()`
was noted on #168 as optional, since neither class holds a `Gson` field and resolving it there means
introducing one rather than deleting a duplicate. It was left out on purpose: both classes are
serialized field-by-field through their own `save()` maps, and adding a field to them is a larger
change than this cleanup warrants. #168 lists it as reasonable to omit.

`CHANGELOG.md` was not touched, as nothing user-visible changed.

## Test plan

- `mvn clean package` — BUILD SUCCESS, shaded JAR produced at `target/Fiefs-0.12.0-SNAPSHOT-8-8-2026.jar`.
- `Tests run: 77, Failures: 0, Errors: 0, Skipped: 0`, including the 14 `StorageServiceTest` cases
  covering the load and save paths, all passing unchanged as #168 anticipated.
- No new test was added: the change has no behavioural effect to assert, and the existing suite passing
  unchanged is the evidence for that.

## Merge hold

`src/main/java/dansplugins/fiefs/services/StorageService.java` is on this repository's fief/claim
persistence path, which is held for human review before merge regardless of how small the change is.
This pull request is therefore left open for the maintainer rather than merged autonomously.

## Backlog not addressed this cycle

- **#167** (dms-conventions alignment) — every item still open under it requires a path that is held
  for human review or authorization that is not available to an autonomous cycle: §1 `CLAUDE.md` is
  agent-loaded configuration, §5 and §6 require `.github/workflows/` and `pom.xml`, and §7 requires
  repository administration access. §2, §3 and §4 landed in #169.
- **#171** (`FiefsAPI.getFief(...)` null wrapper) — deferred as recorded on the issue itself: it is a
  behavioural change to a public API at the Medieval Factions boundary, and the decision belongs to
  the maintainer.

Closes #168

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

---

_drafted by Claude on behalf of Daniel Stephenson_
